### PR TITLE
Feature/ble transport

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,5 +7,5 @@ source =
     smpclient/
 
 [report]
-fail_under = 86.0
+fail_under = 93.4
 show_missing = True

--- a/envr.ps1
+++ b/envr.ps1
@@ -1,4 +1,4 @@
-# envr v0.5.2
+# envr v0.5.3
 # https://www.github.com/JPHutchins/envr
 # https://www.crumpledpaper.tech
 
@@ -664,31 +664,20 @@ $global:_ENVR_NEW_ALIASES.GetEnumerator().ForEach({
         Write-Host "ERROR: only $global:_ALIAS_FN_INDEX aliases allowed!"
         return 1
     }
-    $_TEMP_ARRAY = $val.split(" ")
-    $global:_ALIAS_COMMAND_ARR += ,$_TEMP_ARRAY[0]
-    if ($_TEMP_ARRAY.Length -ge 2) {
-        $_args = @()
-        for (($i = 1); $i -lt $_TEMP_ARRAY.Length; $i++) {
-            # Expand the args to use any environment variables 
-            $_args += ,$ExecutionContext.InvokeCommand.ExpandString($_TEMP_ARRAY[$i])
-        }
-        $global:_ALIAS_ARGS_ARR += ,$_args
-    }
-    else {
-        $global:_ALIAS_ARGS_ARR += ,""
-    }
+
+    $global:_ALIAS_COMMAND_ARR += ,$ExecutionContext.InvokeCommand.ExpandString($val)
 
     # Hack to support aliases with parameters
-    function _ENVR_ALIAS_FN_0 { . $global:_ALIAS_COMMAND_ARR[0] $global:_ALIAS_ARGS_ARR[0] }
-    function _ENVR_ALIAS_FN_1 { . $global:_ALIAS_COMMAND_ARR[1] $global:_ALIAS_ARGS_ARR[1] }
-    function _ENVR_ALIAS_FN_2 { . $global:_ALIAS_COMMAND_ARR[2] $global:_ALIAS_ARGS_ARR[2] }
-    function _ENVR_ALIAS_FN_3 { . $global:_ALIAS_COMMAND_ARR[3] $global:_ALIAS_ARGS_ARR[3] }
-    function _ENVR_ALIAS_FN_4 { . $global:_ALIAS_COMMAND_ARR[4] $global:_ALIAS_ARGS_ARR[4] }
-    function _ENVR_ALIAS_FN_5 { . $global:_ALIAS_COMMAND_ARR[5] $global:_ALIAS_ARGS_ARR[5] }
-    function _ENVR_ALIAS_FN_6 { . $global:_ALIAS_COMMAND_ARR[6] $global:_ALIAS_ARGS_ARR[6] }
-    function _ENVR_ALIAS_FN_7 { . $global:_ALIAS_COMMAND_ARR[7] $global:_ALIAS_ARGS_ARR[7] }
-    function _ENVR_ALIAS_FN_8 { . $global:_ALIAS_COMMAND_ARR[8] $global:_ALIAS_ARGS_ARR[8] }
-    function _ENVR_ALIAS_FN_9 { . $global:_ALIAS_COMMAND_ARR[9] $global:_ALIAS_ARGS_ARR[9] }
+    function _ENVR_ALIAS_FN_0 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[0]) $args" }
+    function _ENVR_ALIAS_FN_1 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[1]) $args" }
+    function _ENVR_ALIAS_FN_2 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[2]) $args" }
+    function _ENVR_ALIAS_FN_3 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[3]) $args" }
+    function _ENVR_ALIAS_FN_4 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[4]) $args" }
+    function _ENVR_ALIAS_FN_5 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[5]) $args" }
+    function _ENVR_ALIAS_FN_6 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[6]) $args" }
+    function _ENVR_ALIAS_FN_7 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[7]) $args" }
+    function _ENVR_ALIAS_FN_8 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[8]) $args" }
+    function _ENVR_ALIAS_FN_9 { Invoke-Expression "$($global:_ALIAS_COMMAND_ARR[9]) $args" }
     Set-Alias -Name $key -Value "_ENVR_ALIAS_FN_$global:_ALIAS_FN_INDEX"
     $global:_ALIAS_FN_INDEX += 1
 })

--- a/poetry.lock
+++ b/poetry.lock
@@ -12,6 +12,17 @@ files = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "4.0.3"
+description = "Timeout context manager for asyncio programs"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"},
+    {file = "async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028"},
+]
+
+[[package]]
 name = "black"
 version = "23.11.0"
 description = "The uncompromising code formatter."
@@ -52,6 +63,53 @@ colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.7.4)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "bleak"
+version = "0.21.1"
+description = "Bluetooth Low Energy platform Agnostic Klient"
+optional = false
+python-versions = ">=3.8,<3.13"
+files = [
+    {file = "bleak-0.21.1-py3-none-any.whl", hash = "sha256:ccec260a0f5ec02dd133d68b0351c0151b2ecf3ddd0bcabc4c04a1cdd7f33256"},
+    {file = "bleak-0.21.1.tar.gz", hash = "sha256:ec4a1a2772fb315b992cbaa1153070c7e26968a52b0e2727035f443a1af5c18f"},
+]
+
+[package.dependencies]
+async-timeout = {version = ">=3.0.0,<5", markers = "python_version < \"3.11\""}
+bleak-winrt = {version = ">=1.2.0,<2.0.0", markers = "platform_system == \"Windows\" and python_version < \"3.12\""}
+dbus-fast = {version = ">=1.83.0,<3", markers = "platform_system == \"Linux\""}
+pyobjc-core = {version = ">=9.2,<10.0", markers = "platform_system == \"Darwin\""}
+pyobjc-framework-CoreBluetooth = {version = ">=9.2,<10.0", markers = "platform_system == \"Darwin\""}
+pyobjc-framework-libdispatch = {version = ">=9.2,<10.0", markers = "platform_system == \"Darwin\""}
+typing-extensions = {version = ">=4.7.0", markers = "python_version < \"3.12\""}
+"winrt-Windows.Devices.Bluetooth" = {version = "2.0.0b1", markers = "platform_system == \"Windows\" and python_version >= \"3.12\""}
+"winrt-Windows.Devices.Bluetooth.Advertisement" = {version = "2.0.0b1", markers = "platform_system == \"Windows\" and python_version >= \"3.12\""}
+"winrt-Windows.Devices.Bluetooth.GenericAttributeProfile" = {version = "2.0.0b1", markers = "platform_system == \"Windows\" and python_version >= \"3.12\""}
+"winrt-Windows.Devices.Enumeration" = {version = "2.0.0b1", markers = "platform_system == \"Windows\" and python_version >= \"3.12\""}
+"winrt-Windows.Foundation" = {version = "2.0.0b1", markers = "platform_system == \"Windows\" and python_version >= \"3.12\""}
+"winrt-Windows.Foundation.Collections" = {version = "2.0.0b1", markers = "platform_system == \"Windows\" and python_version >= \"3.12\""}
+"winrt-Windows.Storage.Streams" = {version = "2.0.0b1", markers = "platform_system == \"Windows\" and python_version >= \"3.12\""}
+
+[[package]]
+name = "bleak-winrt"
+version = "1.2.0"
+description = "Python WinRT bindings for Bleak"
+optional = false
+python-versions = "*"
+files = [
+    {file = "bleak-winrt-1.2.0.tar.gz", hash = "sha256:0577d070251b9354fc6c45ffac57e39341ebb08ead014b1bdbd43e211d2ce1d6"},
+    {file = "bleak_winrt-1.2.0-cp310-cp310-win32.whl", hash = "sha256:a2ae3054d6843ae0cfd3b94c83293a1dfd5804393977dd69bde91cb5099fc47c"},
+    {file = "bleak_winrt-1.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:677df51dc825c6657b3ae94f00bd09b8ab88422b40d6a7bdbf7972a63bc44e9a"},
+    {file = "bleak_winrt-1.2.0-cp311-cp311-win32.whl", hash = "sha256:9449cdb942f22c9892bc1ada99e2ccce9bea8a8af1493e81fefb6de2cb3a7b80"},
+    {file = "bleak_winrt-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:98c1b5a6a6c431ac7f76aa4285b752fe14a1c626bd8a1dfa56f66173ff120bee"},
+    {file = "bleak_winrt-1.2.0-cp37-cp37m-win32.whl", hash = "sha256:623ac511696e1f58d83cb9c431e32f613395f2199b3db7f125a3d872cab968a4"},
+    {file = "bleak_winrt-1.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:13ab06dec55469cf51a2c187be7b630a7a2922e1ea9ac1998135974a7239b1e3"},
+    {file = "bleak_winrt-1.2.0-cp38-cp38-win32.whl", hash = "sha256:5a36ff8cd53068c01a795a75d2c13054ddc5f99ce6de62c1a97cd343fc4d0727"},
+    {file = "bleak_winrt-1.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:810c00726653a962256b7acd8edf81ab9e4a3c66e936a342ce4aec7dbd3a7263"},
+    {file = "bleak_winrt-1.2.0-cp39-cp39-win32.whl", hash = "sha256:dd740047a08925bde54bec357391fcee595d7b8ca0c74c87170a5cbc3f97aa0a"},
+    {file = "bleak_winrt-1.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:63130c11acfe75c504a79c01f9919e87f009f5e742bfc7b7a5c2a9c72bf591a7"},
+]
 
 [[package]]
 name = "cbor2"
@@ -204,6 +262,49 @@ optional = false
 python-versions = "*"
 files = [
     {file = "crcmod-1.7.tar.gz", hash = "sha256:dc7051a0db5f2bd48665a990d3ec1cc305a466a77358ca4492826f41f283601e"},
+]
+
+[[package]]
+name = "dbus-fast"
+version = "2.21.0"
+description = "A faster version of dbus-next"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "dbus_fast-2.21.0-cp310-cp310-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:67fc9ca7c8fa6dec14950f3f785eab78256cb1533c0a2a6237e8dfec9dfb03a5"},
+    {file = "dbus_fast-2.21.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45e9296254a8e6ba827c6ba77d9967111c9bd010525c341aede9eb4a3eb9baef"},
+    {file = "dbus_fast-2.21.0-cp310-cp310-manylinux_2_31_x86_64.whl", hash = "sha256:6a46b180102be81c2146d7b924444cb414cb742e0944133ed0c1f90ebe64c1cb"},
+    {file = "dbus_fast-2.21.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:4b9f40e28a12b0322eb7d32c1405e5da29a109fd51628f56e8897cf85127b6d5"},
+    {file = "dbus_fast-2.21.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fb0bb066f4c449830480cc0a20b6ccb4f2581d06876b2150b328cee184ff33ee"},
+    {file = "dbus_fast-2.21.0-cp311-cp311-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:cb47669f8bd14d2d55d853b3ce501f36981a4fb088a8168adc91b19b9110a05a"},
+    {file = "dbus_fast-2.21.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ef1474209830eabe482f52be85af4d38af83bb021a6fe24a28450c091af5a93"},
+    {file = "dbus_fast-2.21.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c4e623fdd921430c02c584fba922d2d67c76d5afd97013072ea9623d4fd44613"},
+    {file = "dbus_fast-2.21.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:b4bbd7d1deec9ecb5ef8bc5e5e9fcb87f0f8d6f3157e7e3318c54f8b013e18be"},
+    {file = "dbus_fast-2.21.0-cp312-cp312-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:88f39f55e2cda6564c4fb9759aeb8354434e0d5778679f2654dfe489e3b597a4"},
+    {file = "dbus_fast-2.21.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e429c8c416afad4321b9717b71e120bc19258d62d13f9b0a392f24136fb1903"},
+    {file = "dbus_fast-2.21.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:63fff86527b4f9881d4a501ab613e497c72a4a97929ac2dd777cd26ebc1379fa"},
+    {file = "dbus_fast-2.21.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:6c4a2b1340b59d67813b06a6b91e9092c32b81fbefbc0d38c3bcdeabac4bc902"},
+    {file = "dbus_fast-2.21.0-cp37-cp37m-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:5a264d8ab81cbedb0235dc4b8dd1a5b7df44b07c42a1b0a4198fd6fec1d5dda2"},
+    {file = "dbus_fast-2.21.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5a6e59927aaef2f55628ba177561c164859a36388dfc7a4c9c9d76c378efcb6"},
+    {file = "dbus_fast-2.21.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:bf253e1a421ef395a43903e340d83ee9657e33ad694a5b45c9b438aa84ccc38a"},
+    {file = "dbus_fast-2.21.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:23db07bae0cdd4269f40432e53b7bd82a2cc4d287be88d265f50e53f944ed3cc"},
+    {file = "dbus_fast-2.21.0-cp38-cp38-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:18a10b49d208a3ea68f3a62d4d82e42638cc19521a04b5ffd3a6554f41c3e043"},
+    {file = "dbus_fast-2.21.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:240d604578321f7b949b436f0f7f6097617c3a9ff70a2ce28378f5c2d9501571"},
+    {file = "dbus_fast-2.21.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:921188573afadbefb37503768e2b7b3e381c648358e9d9413a7466fb6fb1d4a8"},
+    {file = "dbus_fast-2.21.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:01ea44dad016e684e27615cd8ea9afd5ddfb0409d031f8ab85d540a5f78722e9"},
+    {file = "dbus_fast-2.21.0-cp39-cp39-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:fabbb50bcda006b1e48d4a343ee96050c43fcbc30dd9856080378ef2b3465870"},
+    {file = "dbus_fast-2.21.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:edddabd57733b4a6c5348ac2e58b662d042df9070ebac867753a93d6b5589e2a"},
+    {file = "dbus_fast-2.21.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:fed1a8cd5d11416a8bcce9e588a4372d6d62c76dec275798d07095d699671885"},
+    {file = "dbus_fast-2.21.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:08d490288daa283de619eaac34c6863d9bd7ecea5a5a59b02d7a59d7214a3b59"},
+    {file = "dbus_fast-2.21.0-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:ad4aa825c58458fe333fc5e41cfd29c22947c1c30d500bccc2e39fc15787dea0"},
+    {file = "dbus_fast-2.21.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d9e91c0db2e2452f9cf6c80b94edfddefd01b9b89fe8621f58296b8c29986997"},
+    {file = "dbus_fast-2.21.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:63affae84c36884266cb63fde0e148d4aeab26d76243e4496f3f3568f17e23d7"},
+    {file = "dbus_fast-2.21.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3bb6d7c91e35fbb5e9fb24acdceb512de31ab5a752e0818a683394e852b9654"},
+    {file = "dbus_fast-2.21.0-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:b0bd86710736d2ca438987a64e9627710886c75ff7aacb590181fa896a9102e4"},
+    {file = "dbus_fast-2.21.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:19dbd4b4834947f2b78d5d29ca934e0cc2a98a4c256aa071103168f0805676ea"},
+    {file = "dbus_fast-2.21.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:e46e1b5e98318c4f95e1f3ea041eec646979c4da069167c2b6f4cd3e54d027cc"},
+    {file = "dbus_fast-2.21.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d87ce29c43b92123969ef9c42d7b599d315d9973ed8d69acfafc655d41c40faf"},
+    {file = "dbus_fast-2.21.0.tar.gz", hash = "sha256:f582f6f16791ced6067dab325fae444edf7ce0704315b90c2a473090636a6fe0"},
 ]
 
 [[package]]
@@ -555,6 +656,80 @@ files = [
 ]
 
 [[package]]
+name = "pyobjc-core"
+version = "9.2"
+description = "Python<->ObjC Interoperability Module"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyobjc-core-9.2.tar.gz", hash = "sha256:d734b9291fec91ff4e3ae38b9c6839debf02b79c07314476e87da8e90b2c68c3"},
+    {file = "pyobjc_core-9.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:fa674a39949f5cde8e5c7bbcd24496446bfc67592b028aedbec7f81dc5fc4daa"},
+    {file = "pyobjc_core-9.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bbc8de304ee322a1ee530b4d2daca135a49b4a49aa3cedc6b2c26c43885f4842"},
+    {file = "pyobjc_core-9.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:0fa950f092673883b8bd28bc18397415cabb457bf410920762109b411789ade9"},
+    {file = "pyobjc_core-9.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:586e4cae966282eaa61b21cae66ccdcee9d69c036979def26eebdc08ddebe20f"},
+    {file = "pyobjc_core-9.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:41189c2c680931c0395a55691763c481fc681f454f21bb4f1644f98c24a45954"},
+    {file = "pyobjc_core-9.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:2d23ee539f2ba5e9f5653d75a13f575c7e36586fc0086792739e69e4c2617eda"},
+    {file = "pyobjc_core-9.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b9809cf96678797acb72a758f34932fe8e2602d5ab7abec15c5ac68ddb481720"},
+]
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "9.2"
+description = "Wrappers for the Cocoa frameworks on macOS"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyobjc-framework-Cocoa-9.2.tar.gz", hash = "sha256:efd78080872d8c8de6c2b97e0e4eac99d6203a5d1637aa135d071d464eb2db53"},
+    {file = "pyobjc_framework_Cocoa-9.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9e02d8a7cc4eb7685377c50ba4f17345701acf4c05b1e7480d421bff9e2f62a4"},
+    {file = "pyobjc_framework_Cocoa-9.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3b1e6287b3149e4c6679cdbccd8e9ef6557a4e492a892e80a77df143f40026d2"},
+    {file = "pyobjc_framework_Cocoa-9.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:312977ce2e3989073c6b324c69ba24283de206fe7acd6dbbbaf3e29238a22537"},
+    {file = "pyobjc_framework_Cocoa-9.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:aae7841cf40c26dd915f4dd828f91c6616e6b7998630b72e704750c09e00f334"},
+    {file = "pyobjc_framework_Cocoa-9.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:739a421e14382a46cbeb9a883f192dceff368ad28ec34d895c48c0ad34cf2c1d"},
+    {file = "pyobjc_framework_Cocoa-9.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:32d9ac1033fac1b821ddee8c68f972a7074ad8c50bec0bea9a719034c1c2fb94"},
+    {file = "pyobjc_framework_Cocoa-9.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b236bb965e41aeb2e215d4e98a5a230d4b63252c6d26e00924ea2e69540a59d6"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=9.2"
+
+[[package]]
+name = "pyobjc-framework-corebluetooth"
+version = "9.2"
+description = "Wrappers for the framework CoreBluetooth on macOS"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyobjc-framework-CoreBluetooth-9.2.tar.gz", hash = "sha256:cb2481b1dfe211ae9ce55f36537dc8155dbf0dc8ff26e0bc2e13f7afb0a291d1"},
+    {file = "pyobjc_framework_CoreBluetooth-9.2-cp36-abi3-macosx_10_9_universal2.whl", hash = "sha256:53d888742119d0f0c725d0b0c2389f68e8f21f0cba6d6aec288c53260a0196b6"},
+    {file = "pyobjc_framework_CoreBluetooth-9.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:179532882126526e38fe716a50fb0ee8f440e0b838d290252c515e622b5d0e49"},
+    {file = "pyobjc_framework_CoreBluetooth-9.2-cp36-abi3-macosx_11_0_universal2.whl", hash = "sha256:256a5031ea9d8a7406541fa1b0dfac549b1de93deae8284605f9355b13fb58be"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=9.2"
+pyobjc-framework-Cocoa = ">=9.2"
+
+[[package]]
+name = "pyobjc-framework-libdispatch"
+version = "9.2"
+description = "Wrappers for libdispatch on macOS"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyobjc-framework-libdispatch-9.2.tar.gz", hash = "sha256:542e7f7c2b041939db5ed6f3119c1d67d73ec14a996278b92485f8513039c168"},
+    {file = "pyobjc_framework_libdispatch-9.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:88d4091d4bcb5702783d6e86b4107db973425a17d1de491543f56bd348909b60"},
+    {file = "pyobjc_framework_libdispatch-9.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1a67b007113328538b57893cc7829a722270764cdbeae6d5e1460a1d911314df"},
+    {file = "pyobjc_framework_libdispatch-9.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:6fccea1a57436cf1ac50d9ebc6e3e725bcf77f829ba6b118e62e6ed7866d359d"},
+    {file = "pyobjc_framework_libdispatch-9.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6eba747b7ad91b0463265a7aee59235bb051fb97687f35ca2233690369b5e4e4"},
+    {file = "pyobjc_framework_libdispatch-9.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2e835495860d04f63c2d2f73ae3dd79da4222864c107096dc0f99e8382700026"},
+    {file = "pyobjc_framework_libdispatch-9.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:1b107e5c3580b09553030961ea6b17abad4a5132101eab1af3ad2cb36d0f08bb"},
+    {file = "pyobjc_framework_libdispatch-9.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:83cdb672acf722717b5ecf004768f215f02ac02d7f7f2a9703da6e921ab02222"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=9.2"
+
+[[package]]
 name = "pyserial"
 version = "3.5"
 description = "Python Serial Port Extension"
@@ -654,6 +829,17 @@ files = [
 ]
 
 [[package]]
+name = "types-pyserial"
+version = "3.5.0.11"
+description = "Typing stubs for pyserial"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "types-pyserial-3.5.0.11.tar.gz", hash = "sha256:997fcaadfe00386cd80f789a42a5febce4d65774e17e3396d91cac6345b9aab2"},
+    {file = "types_pyserial-3.5.0.11-py3-none-any.whl", hash = "sha256:db80b56868b1bcc5667ec25bacb9bf5adaa397daa6225e95466f37370c6bc626"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.8.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -664,7 +850,225 @@ files = [
     {file = "typing_extensions-4.8.0.tar.gz", hash = "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"},
 ]
 
+[[package]]
+name = "winrt-runtime"
+version = "2.0.0b1"
+description = "Python projection of Windows Runtime (WinRT) APIs"
+optional = false
+python-versions = "<3.13,>=3.9"
+files = [
+    {file = "winrt-runtime-2.0.0b1.tar.gz", hash = "sha256:28db2ebe7bfb347d110224e9f23fe8079cea45af0fcbd643d039524ced07d22c"},
+    {file = "winrt_runtime-2.0.0b1-cp310-cp310-win32.whl", hash = "sha256:8f812b01e2c8dd3ca68aa51a7aa02e815cc2ac3c8520a883b4ec7a4fc63afb04"},
+    {file = "winrt_runtime-2.0.0b1-cp310-cp310-win_amd64.whl", hash = "sha256:f36f6102f9b7a08d917a6809117c085639b66be2c579f4089d3fd47b83e8f87b"},
+    {file = "winrt_runtime-2.0.0b1-cp310-cp310-win_arm64.whl", hash = "sha256:4a99f267da96edc977623355b816b46c1344c66dc34732857084417d8cf9a96b"},
+    {file = "winrt_runtime-2.0.0b1-cp311-cp311-win32.whl", hash = "sha256:ba998e3fc452338c5e2d7bf5174a6206580245066d60079ee4130082d0eb61c2"},
+    {file = "winrt_runtime-2.0.0b1-cp311-cp311-win_amd64.whl", hash = "sha256:e7838f0fdf5653ce245888590214177a1f54884cece2c8dfbfe3d01b2780171e"},
+    {file = "winrt_runtime-2.0.0b1-cp311-cp311-win_arm64.whl", hash = "sha256:2afa45b7385e99a63d55ccda29096e6a84fcd4c654479005c147b0e65e274abf"},
+    {file = "winrt_runtime-2.0.0b1-cp312-cp312-win32.whl", hash = "sha256:edda124ff965cec3a6bfdb26fbe88e004f96975dd84115176e30c1efbcb16f4c"},
+    {file = "winrt_runtime-2.0.0b1-cp312-cp312-win_amd64.whl", hash = "sha256:d8935951efeec6b3d546dce8f48bb203aface57a1ba991c066f0e12e84c8f91e"},
+    {file = "winrt_runtime-2.0.0b1-cp312-cp312-win_arm64.whl", hash = "sha256:509fb9a03af5e1125433f58522725716ceef040050d33625460b5a5eb98a46ac"},
+    {file = "winrt_runtime-2.0.0b1-cp39-cp39-win32.whl", hash = "sha256:41138fe4642345d7143e817ce0905d82e60b3832558143e0a17bfea8654c6512"},
+    {file = "winrt_runtime-2.0.0b1-cp39-cp39-win_amd64.whl", hash = "sha256:081a429fe85c33cb6610c4a799184b7650b30f15ab1d89866f2bda246d3a5c0a"},
+    {file = "winrt_runtime-2.0.0b1-cp39-cp39-win_arm64.whl", hash = "sha256:e6984604c6ae1f3258973ba2503d1ea5aa15e536ca41d6a131ad305ebbb6519d"},
+]
+
+[[package]]
+name = "winrt-windows-devices-bluetooth"
+version = "2.0.0b1"
+description = "Python projection of Windows Runtime (WinRT) APIs"
+optional = false
+python-versions = "<3.13,>=3.9"
+files = [
+    {file = "winrt-Windows.Devices.Bluetooth-2.0.0b1.tar.gz", hash = "sha256:786bd43786b873a083b89debece538974f720584662a2573d6a8a8501a532860"},
+    {file = "winrt_Windows.Devices.Bluetooth-2.0.0b1-cp310-cp310-win32.whl", hash = "sha256:79631bf3f96954da260859df9228a028835ffade0d885ba3942c5a86a853d150"},
+    {file = "winrt_Windows.Devices.Bluetooth-2.0.0b1-cp310-cp310-win_amd64.whl", hash = "sha256:cd85337a95065d0d2045c06db1a5edd4a447aad47cf7027818f6fb69f831c56c"},
+    {file = "winrt_Windows.Devices.Bluetooth-2.0.0b1-cp310-cp310-win_arm64.whl", hash = "sha256:6a963869ed003d260e90e9bedc334129303f263f068ea1c0d994df53317db2bc"},
+    {file = "winrt_Windows.Devices.Bluetooth-2.0.0b1-cp311-cp311-win32.whl", hash = "sha256:7c5951943a3911d94a8da190f4355dc70128d7d7f696209316372c834b34d462"},
+    {file = "winrt_Windows.Devices.Bluetooth-2.0.0b1-cp311-cp311-win_amd64.whl", hash = "sha256:b0bb154ae92235649ed234982f609c490a467d5049c27d63397be9abbb00730e"},
+    {file = "winrt_Windows.Devices.Bluetooth-2.0.0b1-cp311-cp311-win_arm64.whl", hash = "sha256:6688dfb0fc3b7dc517bf8cf40ae00544a50b4dec91470d37be38fc33c4523632"},
+    {file = "winrt_Windows.Devices.Bluetooth-2.0.0b1-cp312-cp312-win32.whl", hash = "sha256:613c6ff4125df46189b3bef6d3110d94ec725d357ab734f00eedb11c4116c367"},
+    {file = "winrt_Windows.Devices.Bluetooth-2.0.0b1-cp312-cp312-win_amd64.whl", hash = "sha256:59c403b64e9f4e417599c6f6aea6ee6fac960597c21eac6b3fd8a84f64aa387c"},
+    {file = "winrt_Windows.Devices.Bluetooth-2.0.0b1-cp312-cp312-win_arm64.whl", hash = "sha256:b7f6e1b9bb6e33be80045adebd252cf25cd648759fad6e86c61a393ddd709f7f"},
+    {file = "winrt_Windows.Devices.Bluetooth-2.0.0b1-cp39-cp39-win32.whl", hash = "sha256:eae7a89106eab047e96843e28c3c6ce0886dd7dee60180a1010498925e9503f9"},
+    {file = "winrt_Windows.Devices.Bluetooth-2.0.0b1-cp39-cp39-win_amd64.whl", hash = "sha256:8dfd1915c894ac19dd0b24aba38ef676c92c3473c0d9826762ba9616ad7df68b"},
+    {file = "winrt_Windows.Devices.Bluetooth-2.0.0b1-cp39-cp39-win_arm64.whl", hash = "sha256:49058587e6d82ba33da0767b97a378ddfea8e3a5991bdeff680faa287bfae57e"},
+]
+
+[package.dependencies]
+winrt-runtime = "2.0.0-beta.1"
+
+[package.extras]
+all = ["winrt-Windows.Devices.Bluetooth.GenericAttributeProfile[all] (==2.0.0-beta.1)", "winrt-Windows.Devices.Bluetooth.Rfcomm[all] (==2.0.0-beta.1)", "winrt-Windows.Devices.Enumeration[all] (==2.0.0-beta.1)", "winrt-Windows.Devices.Radios[all] (==2.0.0-beta.1)", "winrt-Windows.Foundation.Collections[all] (==2.0.0-beta.1)", "winrt-Windows.Foundation[all] (==2.0.0-beta.1)", "winrt-Windows.Networking[all] (==2.0.0-beta.1)", "winrt-Windows.Storage.Streams[all] (==2.0.0-beta.1)"]
+
+[[package]]
+name = "winrt-windows-devices-bluetooth-advertisement"
+version = "2.0.0b1"
+description = "Python projection of Windows Runtime (WinRT) APIs"
+optional = false
+python-versions = "<3.13,>=3.9"
+files = [
+    {file = "winrt-Windows.Devices.Bluetooth.Advertisement-2.0.0b1.tar.gz", hash = "sha256:d9050faa4377d410d4f0e9cabb5ec555a267531c9747370555ac9ec93ec9f399"},
+    {file = "winrt_Windows.Devices.Bluetooth.Advertisement-2.0.0b1-cp310-cp310-win32.whl", hash = "sha256:ac9b703d16adc87c3541585525b8fcf6d84391e2fa010c2f001e714c405cc3b7"},
+    {file = "winrt_Windows.Devices.Bluetooth.Advertisement-2.0.0b1-cp310-cp310-win_amd64.whl", hash = "sha256:593cade7853a8b0770e8ef30462b5d5f477b82e17e0aa590094b1c26efd3e05a"},
+    {file = "winrt_Windows.Devices.Bluetooth.Advertisement-2.0.0b1-cp310-cp310-win_arm64.whl", hash = "sha256:574698c08895e2cfee7379bdf34a5f319fe440d7dfcc7bc9858f457c08e9712c"},
+    {file = "winrt_Windows.Devices.Bluetooth.Advertisement-2.0.0b1-cp311-cp311-win32.whl", hash = "sha256:652a096f8210036bbb539d7f971eaf1f472a3aeb60b7e31278e3d0d30a355292"},
+    {file = "winrt_Windows.Devices.Bluetooth.Advertisement-2.0.0b1-cp311-cp311-win_amd64.whl", hash = "sha256:e5cfb866c44dad644fb44b441f4fdbddafc9564075f1f68f756e20f438105c67"},
+    {file = "winrt_Windows.Devices.Bluetooth.Advertisement-2.0.0b1-cp311-cp311-win_arm64.whl", hash = "sha256:6c2503eaaf5cd988b5510b86347dba45ad6ee52656f9656a1a97abae6d35386e"},
+    {file = "winrt_Windows.Devices.Bluetooth.Advertisement-2.0.0b1-cp312-cp312-win32.whl", hash = "sha256:780c766725a55f4211f921c773c92c2331803e70f65d6ad6676a60f903d39a54"},
+    {file = "winrt_Windows.Devices.Bluetooth.Advertisement-2.0.0b1-cp312-cp312-win_amd64.whl", hash = "sha256:39c8633d01039eb2c2f6f20cfc43c045a333b9f3a45229e2ce443f71bb2a562c"},
+    {file = "winrt_Windows.Devices.Bluetooth.Advertisement-2.0.0b1-cp312-cp312-win_arm64.whl", hash = "sha256:eaa0d44b4158b16937eac8102249e792f0299dbb0aefc56cc9adc9552e8f9afe"},
+    {file = "winrt_Windows.Devices.Bluetooth.Advertisement-2.0.0b1-cp39-cp39-win32.whl", hash = "sha256:d171487e23f7671ad2923544bfa6545d0a29a1a9ae1f5c1d5e5e5f473a5d62b2"},
+    {file = "winrt_Windows.Devices.Bluetooth.Advertisement-2.0.0b1-cp39-cp39-win_amd64.whl", hash = "sha256:442eecac87653a03617e65bdb2ef79ddc0582dfdacc2be8af841fba541577f8b"},
+    {file = "winrt_Windows.Devices.Bluetooth.Advertisement-2.0.0b1-cp39-cp39-win_arm64.whl", hash = "sha256:b30ab9b8c1ecf818be08bac86bee425ef40f75060c4011d4e6c2e624a7b9916e"},
+]
+
+[package.dependencies]
+winrt-runtime = "2.0.0-beta.1"
+
+[package.extras]
+all = ["winrt-Windows.Devices.Bluetooth[all] (==2.0.0-beta.1)", "winrt-Windows.Foundation.Collections[all] (==2.0.0-beta.1)", "winrt-Windows.Foundation[all] (==2.0.0-beta.1)", "winrt-Windows.Storage.Streams[all] (==2.0.0-beta.1)"]
+
+[[package]]
+name = "winrt-windows-devices-bluetooth-genericattributeprofile"
+version = "2.0.0b1"
+description = "Python projection of Windows Runtime (WinRT) APIs"
+optional = false
+python-versions = "<3.13,>=3.9"
+files = [
+    {file = "winrt-Windows.Devices.Bluetooth.GenericAttributeProfile-2.0.0b1.tar.gz", hash = "sha256:93b745d51ecfb3e9d3a21623165cc065735c9e0146cb7a26744182c164e63e14"},
+    {file = "winrt_Windows.Devices.Bluetooth.GenericAttributeProfile-2.0.0b1-cp310-cp310-win32.whl", hash = "sha256:db740aaedd80cca5b1a390663b26c7733eb08f4c57ade6a04b055d548e9d042b"},
+    {file = "winrt_Windows.Devices.Bluetooth.GenericAttributeProfile-2.0.0b1-cp310-cp310-win_amd64.whl", hash = "sha256:7c81aa6c066cdab58bcc539731f208960e094a6d48b59118898e1e804dbbdf7f"},
+    {file = "winrt_Windows.Devices.Bluetooth.GenericAttributeProfile-2.0.0b1-cp310-cp310-win_arm64.whl", hash = "sha256:92277a6bbcbe2225ad1be92968af597dc77bc37a63cd729690d2d9fb5094ae25"},
+    {file = "winrt_Windows.Devices.Bluetooth.GenericAttributeProfile-2.0.0b1-cp311-cp311-win32.whl", hash = "sha256:6b48209669c1e214165530793cf9916ae44a0ae2618a9be7a489e8c94f7e745f"},
+    {file = "winrt_Windows.Devices.Bluetooth.GenericAttributeProfile-2.0.0b1-cp311-cp311-win_amd64.whl", hash = "sha256:2f17216e6ce748eaef02fb0658213515d3ff31e2dbb18f070a614876f818c90d"},
+    {file = "winrt_Windows.Devices.Bluetooth.GenericAttributeProfile-2.0.0b1-cp311-cp311-win_arm64.whl", hash = "sha256:db798a0f0762e390da5a9f02f822daff00692bd951a492224bf46782713b2938"},
+    {file = "winrt_Windows.Devices.Bluetooth.GenericAttributeProfile-2.0.0b1-cp312-cp312-win32.whl", hash = "sha256:b8d9dba04b9cfa53971c35117fc3c68c94bfa5e2ed18ce680f731743598bf246"},
+    {file = "winrt_Windows.Devices.Bluetooth.GenericAttributeProfile-2.0.0b1-cp312-cp312-win_amd64.whl", hash = "sha256:e5260b3f33dee8a896604297e05efc04d04298329c205a74ded8e2d6333e84b7"},
+    {file = "winrt_Windows.Devices.Bluetooth.GenericAttributeProfile-2.0.0b1-cp312-cp312-win_arm64.whl", hash = "sha256:822ef539389ecb546004345c4dce8b9b7788e2e99a1d6f0947a4b123dceb7fed"},
+    {file = "winrt_Windows.Devices.Bluetooth.GenericAttributeProfile-2.0.0b1-cp39-cp39-win32.whl", hash = "sha256:11e6863e7a94d2b6dd76ddcd19c01e311895810a4ce6ad08c7b5534294753243"},
+    {file = "winrt_Windows.Devices.Bluetooth.GenericAttributeProfile-2.0.0b1-cp39-cp39-win_amd64.whl", hash = "sha256:20de8d04c301c406362c93e78d41912aea0af23c4b430704aba329420d7c2cdf"},
+    {file = "winrt_Windows.Devices.Bluetooth.GenericAttributeProfile-2.0.0b1-cp39-cp39-win_arm64.whl", hash = "sha256:918059796f2f123216163b928ecde8ecec17994fb7a94042af07fda82c132a6d"},
+]
+
+[package.dependencies]
+winrt-runtime = "2.0.0-beta.1"
+
+[package.extras]
+all = ["winrt-Windows.Devices.Bluetooth[all] (==2.0.0-beta.1)", "winrt-Windows.Devices.Enumeration[all] (==2.0.0-beta.1)", "winrt-Windows.Foundation.Collections[all] (==2.0.0-beta.1)", "winrt-Windows.Foundation[all] (==2.0.0-beta.1)", "winrt-Windows.Storage.Streams[all] (==2.0.0-beta.1)"]
+
+[[package]]
+name = "winrt-windows-devices-enumeration"
+version = "2.0.0b1"
+description = "Python projection of Windows Runtime (WinRT) APIs"
+optional = false
+python-versions = "<3.13,>=3.9"
+files = [
+    {file = "winrt-Windows.Devices.Enumeration-2.0.0b1.tar.gz", hash = "sha256:8f214040e4edbe57c4943488887db89f4a00d028c34169aafd2205e228026100"},
+    {file = "winrt_Windows.Devices.Enumeration-2.0.0b1-cp310-cp310-win32.whl", hash = "sha256:dcb9e7d230aefec8531a46d393ecb1063b9d4b97c9f3ff2fc537ce22bdfa2444"},
+    {file = "winrt_Windows.Devices.Enumeration-2.0.0b1-cp310-cp310-win_amd64.whl", hash = "sha256:22a3e1fef40786cc8d51320b6f11ff25de6c674475f3ba608a46915e1dadf0f5"},
+    {file = "winrt_Windows.Devices.Enumeration-2.0.0b1-cp310-cp310-win_arm64.whl", hash = "sha256:2edcfeb70a71d40622873cad96982a28e92a7ee71f33968212dd3598b2d8d469"},
+    {file = "winrt_Windows.Devices.Enumeration-2.0.0b1-cp311-cp311-win32.whl", hash = "sha256:ce4eb88add7f5946d2666761a97a3bb04cac2a061d264f03229c1e15dbd7ce91"},
+    {file = "winrt_Windows.Devices.Enumeration-2.0.0b1-cp311-cp311-win_amd64.whl", hash = "sha256:a9001f17991572abdddab7ab074e08046e74e05eeeaf3b2b01b8b47d2879b64c"},
+    {file = "winrt_Windows.Devices.Enumeration-2.0.0b1-cp311-cp311-win_arm64.whl", hash = "sha256:0440b91ce144111e207f084cec6b1277162ef2df452d321951e989ce87dc9ced"},
+    {file = "winrt_Windows.Devices.Enumeration-2.0.0b1-cp312-cp312-win32.whl", hash = "sha256:e4fae13126f13a8d9420b74fb5a5ff6a6b2f91f7718c4be2d4a8dc1337c58f59"},
+    {file = "winrt_Windows.Devices.Enumeration-2.0.0b1-cp312-cp312-win_amd64.whl", hash = "sha256:e352eebc23dc94fb79e67a056c057fb0e16c20c8cb881dc826094c20ed4791e3"},
+    {file = "winrt_Windows.Devices.Enumeration-2.0.0b1-cp312-cp312-win_arm64.whl", hash = "sha256:b43f5c1f053a170e6e4b44ba69838ac223f9051adca1a56506d4c46e98d1485f"},
+    {file = "winrt_Windows.Devices.Enumeration-2.0.0b1-cp39-cp39-win32.whl", hash = "sha256:ed245fad8de6a134d5c3a630204e7f8238aa944a40388005bce0ce3718c410fa"},
+    {file = "winrt_Windows.Devices.Enumeration-2.0.0b1-cp39-cp39-win_amd64.whl", hash = "sha256:22a9eefdbfe520778512266d0b48ff239eaa8d272fce6f5cb1ff352bed0619f4"},
+    {file = "winrt_Windows.Devices.Enumeration-2.0.0b1-cp39-cp39-win_arm64.whl", hash = "sha256:397d43f8fd2621a7719b9eab6a4a8e72a1d6fa2d9c36525a30812f8e7bad3bdf"},
+]
+
+[package.dependencies]
+winrt-runtime = "2.0.0-beta.1"
+
+[package.extras]
+all = ["winrt-Windows.ApplicationModel.Background[all] (==2.0.0-beta.1)", "winrt-Windows.Foundation.Collections[all] (==2.0.0-beta.1)", "winrt-Windows.Foundation[all] (==2.0.0-beta.1)", "winrt-Windows.Security.Credentials[all] (==2.0.0-beta.1)", "winrt-Windows.Storage.Streams[all] (==2.0.0-beta.1)", "winrt-Windows.UI.Popups[all] (==2.0.0-beta.1)", "winrt-Windows.UI[all] (==2.0.0-beta.1)"]
+
+[[package]]
+name = "winrt-windows-foundation"
+version = "2.0.0b1"
+description = "Python projection of Windows Runtime (WinRT) APIs"
+optional = false
+python-versions = "<3.13,>=3.9"
+files = [
+    {file = "winrt-Windows.Foundation-2.0.0b1.tar.gz", hash = "sha256:976b6da942747a7ca5a179a35729d8dc163f833e03b085cf940332a5e9070d54"},
+    {file = "winrt_Windows.Foundation-2.0.0b1-cp310-cp310-win32.whl", hash = "sha256:5337ac1ec260132fbff868603e73a3738d4001911226e72669b3d69c8a256d5e"},
+    {file = "winrt_Windows.Foundation-2.0.0b1-cp310-cp310-win_amd64.whl", hash = "sha256:af969e5bb9e2e41e4e86a361802528eafb5eb8fe87ec1dba6048c0702d63caa8"},
+    {file = "winrt_Windows.Foundation-2.0.0b1-cp310-cp310-win_arm64.whl", hash = "sha256:bbbfa6b3c444a1074a630fd4a1b71171be7a5c9bb07c827ad9259fadaed56cf2"},
+    {file = "winrt_Windows.Foundation-2.0.0b1-cp311-cp311-win32.whl", hash = "sha256:b91bd92b1854c073acd81aa87cf8df571d2151b1dd050b6181aa36f7acc43df4"},
+    {file = "winrt_Windows.Foundation-2.0.0b1-cp311-cp311-win_amd64.whl", hash = "sha256:2f5359f25703347e827dbac982150354069030f1deecd616f7ce37ad90cbcb00"},
+    {file = "winrt_Windows.Foundation-2.0.0b1-cp311-cp311-win_arm64.whl", hash = "sha256:0f1f1978173ddf0ee6262c2edb458f62d628b9fa0df10cd1e8c78c833af3197e"},
+    {file = "winrt_Windows.Foundation-2.0.0b1-cp312-cp312-win32.whl", hash = "sha256:c1d23b737f733104b91c89c507b58d0b3ef5f3234a1b608ef6dfb6dbbb8777ea"},
+    {file = "winrt_Windows.Foundation-2.0.0b1-cp312-cp312-win_amd64.whl", hash = "sha256:95de6c29e9083fe63f127b965b54dfa52a6424a93a94ce87cfad4c1900a6e887"},
+    {file = "winrt_Windows.Foundation-2.0.0b1-cp312-cp312-win_arm64.whl", hash = "sha256:4707063a5a6980e3f71aebeea5ac93101c753ec13a0b47be9ea4dbc0d5ff361e"},
+    {file = "winrt_Windows.Foundation-2.0.0b1-cp39-cp39-win32.whl", hash = "sha256:d0259f1f4a1b8e20d0cbd935a889c0f7234f720645590260f9cf3850fdc1e1fa"},
+    {file = "winrt_Windows.Foundation-2.0.0b1-cp39-cp39-win_amd64.whl", hash = "sha256:15c7b324d0f59839fb4492d84bb1c870881c5c67cb94ac24c664a7c4dce1c475"},
+    {file = "winrt_Windows.Foundation-2.0.0b1-cp39-cp39-win_arm64.whl", hash = "sha256:16ad741f4d38e99f8409ba5760299d0052003255f970f49f4b8ba2e0b609c8b7"},
+]
+
+[package.dependencies]
+winrt-runtime = "2.0.0-beta.1"
+
+[package.extras]
+all = ["winrt-Windows.Foundation.Collections[all] (==2.0.0-beta.1)"]
+
+[[package]]
+name = "winrt-windows-foundation-collections"
+version = "2.0.0b1"
+description = "Python projection of Windows Runtime (WinRT) APIs"
+optional = false
+python-versions = "<3.13,>=3.9"
+files = [
+    {file = "winrt-Windows.Foundation.Collections-2.0.0b1.tar.gz", hash = "sha256:185d30f8103934124544a40aac005fa5918a9a7cb3179f45e9863bb86e22ad43"},
+    {file = "winrt_Windows.Foundation.Collections-2.0.0b1-cp310-cp310-win32.whl", hash = "sha256:042142e916a170778b7154498aae61254a1a94c552954266b73479479d24f01d"},
+    {file = "winrt_Windows.Foundation.Collections-2.0.0b1-cp310-cp310-win_amd64.whl", hash = "sha256:9f68e66055121fc1e04c4fda627834aceee6fbe922e77d6ccaecf9582e714c57"},
+    {file = "winrt_Windows.Foundation.Collections-2.0.0b1-cp310-cp310-win_arm64.whl", hash = "sha256:a4609411263cc7f5e93a9a5677b21e2ef130e26f9030bfa960b3e82595324298"},
+    {file = "winrt_Windows.Foundation.Collections-2.0.0b1-cp311-cp311-win32.whl", hash = "sha256:5296858aa44c53936460a119794b80eedd6bd094016c1bf96822f92cb95ea419"},
+    {file = "winrt_Windows.Foundation.Collections-2.0.0b1-cp311-cp311-win_amd64.whl", hash = "sha256:3db1e1c80c97474e7c88b6052bd8982ca61723fd58ace11dc91a5522662e0b2a"},
+    {file = "winrt_Windows.Foundation.Collections-2.0.0b1-cp311-cp311-win_arm64.whl", hash = "sha256:c3a594e660c59f9fab04ae2f40bda7c809e8ec4748bada4424dfb02b43d4bfe1"},
+    {file = "winrt_Windows.Foundation.Collections-2.0.0b1-cp312-cp312-win32.whl", hash = "sha256:0f355ee943ec5b835e694d97e9e93545a42d6fb984a61f442467789550d62c3f"},
+    {file = "winrt_Windows.Foundation.Collections-2.0.0b1-cp312-cp312-win_amd64.whl", hash = "sha256:c4a0cd2eb9f47c7ca3b66d12341cc822250bf26854a93fd58ab77f7a48dfab3a"},
+    {file = "winrt_Windows.Foundation.Collections-2.0.0b1-cp312-cp312-win_arm64.whl", hash = "sha256:744dbef50e8b8f34904083cae9ad43ac6e28facb9e166c4f123ce8e758141067"},
+    {file = "winrt_Windows.Foundation.Collections-2.0.0b1-cp39-cp39-win32.whl", hash = "sha256:b7c767184aec3a3d7cba2cd84fadcd68106854efabef1a61092052294d6d6f4f"},
+    {file = "winrt_Windows.Foundation.Collections-2.0.0b1-cp39-cp39-win_amd64.whl", hash = "sha256:7c1ffe99c12f14fc4ab7027757780e6d850fa2fb23ec404a54311fbd9f1970d3"},
+    {file = "winrt_Windows.Foundation.Collections-2.0.0b1-cp39-cp39-win_arm64.whl", hash = "sha256:870fa040ed36066e4c240c35973d8b2e0d7c38cc6050a42d993715ec9e3b748c"},
+]
+
+[package.dependencies]
+winrt-runtime = "2.0.0-beta.1"
+
+[package.extras]
+all = ["winrt-Windows.Foundation[all] (==2.0.0-beta.1)"]
+
+[[package]]
+name = "winrt-windows-storage-streams"
+version = "2.0.0b1"
+description = "Python projection of Windows Runtime (WinRT) APIs"
+optional = false
+python-versions = "<3.13,>=3.9"
+files = [
+    {file = "winrt-Windows.Storage.Streams-2.0.0b1.tar.gz", hash = "sha256:029d67cdc9b092d56c682740fe3c42f267dc5d3346b5c0b12ebc03f38e7d2f1f"},
+    {file = "winrt_Windows.Storage.Streams-2.0.0b1-cp310-cp310-win32.whl", hash = "sha256:49c90d4bfd539f6676226dfcb4b3574ddd6be528ffc44aa214c55af88c2de89e"},
+    {file = "winrt_Windows.Storage.Streams-2.0.0b1-cp310-cp310-win_amd64.whl", hash = "sha256:22cc82779cada84aa2633841e25b33f3357737d912a1d9ecc1ee5a8b799b5171"},
+    {file = "winrt_Windows.Storage.Streams-2.0.0b1-cp310-cp310-win_arm64.whl", hash = "sha256:b1750a111be32466f4f0781cbb5df195ac940690571dff4564492b921b162563"},
+    {file = "winrt_Windows.Storage.Streams-2.0.0b1-cp311-cp311-win32.whl", hash = "sha256:e79b1183ab26d9b95cf3e6dbe3f488a40605174a5a112694dbb7dbfb50899daf"},
+    {file = "winrt_Windows.Storage.Streams-2.0.0b1-cp311-cp311-win_amd64.whl", hash = "sha256:3e90a1207eb3076f051a7785132f7b056b37343a68e9481a50c6defb3f660099"},
+    {file = "winrt_Windows.Storage.Streams-2.0.0b1-cp311-cp311-win_arm64.whl", hash = "sha256:4da06522b4fa9cfcc046b604cc4aa1c6a887cc4bb5b8a637ed9bff8028a860bb"},
+    {file = "winrt_Windows.Storage.Streams-2.0.0b1-cp312-cp312-win32.whl", hash = "sha256:6f74f8ab8ac0d8de61c709043315361d8ac63f8144f3098d428472baadf8246a"},
+    {file = "winrt_Windows.Storage.Streams-2.0.0b1-cp312-cp312-win_amd64.whl", hash = "sha256:5cf7c8d67836c60392d167bfe4f98ac7abcb691bfba2d19e322d0f9181f58347"},
+    {file = "winrt_Windows.Storage.Streams-2.0.0b1-cp312-cp312-win_arm64.whl", hash = "sha256:f7f679f2c0f71791eca835856f57942ee5245094c1840a6c34bc7c2176b1bcd6"},
+    {file = "winrt_Windows.Storage.Streams-2.0.0b1-cp39-cp39-win32.whl", hash = "sha256:5beb53429fa9a11ede56b4a7cefe28c774b352dd355f7951f2a4dd7e9ec9b39a"},
+    {file = "winrt_Windows.Storage.Streams-2.0.0b1-cp39-cp39-win_amd64.whl", hash = "sha256:f84233c4b500279d8f5840cb8c47776bc040fcecba05c6c9ab9767053698fc8b"},
+    {file = "winrt_Windows.Storage.Streams-2.0.0b1-cp39-cp39-win_arm64.whl", hash = "sha256:cfb163ddbb435906f75ef92a768573b0190e194e1438cea5a4c1d4d32a6b9386"},
+]
+
+[package.dependencies]
+winrt-runtime = "2.0.0-beta.1"
+
+[package.extras]
+all = ["winrt-Windows.Foundation.Collections[all] (==2.0.0-beta.1)", "winrt-Windows.Foundation[all] (==2.0.0-beta.1)", "winrt-Windows.Storage[all] (==2.0.0-beta.1)", "winrt-Windows.System[all] (==2.0.0-beta.1)"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.13"
-content-hash = "c4c28e13e56b5828a325bf7c77973a0f6fd696ddcefada6aaa6d443395d2bfcf"
+content-hash = "df710e8ea9ce5170f4fc696efe762dd75f50a8eb78972d1aceac8b41459514df"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ python = ">=3.10, <3.13"
 pyserial = "^3.5"
 smp = "^0.1.9"
 intelhex = "^2.3.0"
+bleak = "^0.21.1"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -34,6 +35,7 @@ isort = "^5.12.0"
 mypy = "^1.7.0"
 mypy-extensions = "^1.0.0"
 pytest-asyncio = "^0.23.2"
+types-pyserial = "^3.5.0.11"
 
 [tool.black]
 line-length = 100

--- a/smpclient/__init__.py
+++ b/smpclient/__init__.py
@@ -1,11 +1,10 @@
 """Simple Management Protocol (SMP) Client."""
 
 from hashlib import sha256
-from typing import AsyncIterator
+from typing import AsyncIterator, Final, cast
 
 from pydantic import ValidationError
 from smp import header as smpheader
-from smp import packet as smppacket
 
 from smpclient.exceptions import SMPBadSequence, SMPUploadError
 from smpclient.generics import SMPRequest, TEr0, TEr1, TErr, TRep, error, flatten_error, success
@@ -15,26 +14,22 @@ from smpclient.transport import SMPTransport
 
 class SMPClient:
     def __init__(self, transport: SMPTransport, address: str):
-        self._transport = transport
-        self._address = address
+        """Create a client to the SMP server `address`, using `transport`."""
+        self._transport: Final = transport
+        self._address: Final = address
 
     async def connect(self) -> None:
+        """Connect to the SMP server."""
         await self._transport.connect(self._address)
 
+    async def disconnect(self) -> None:
+        """Disconnect from the SMP server."""
+        await self._transport.disconnect()
+
     async def request(self, request: SMPRequest[TRep, TEr0, TEr1, TErr]) -> TRep | TErr:
-        for packet in smppacket.encode(request.BYTES):
-            await self._transport.send(packet)
+        """Make an `SMPRequest` to the SMP server."""
 
-        decoder = smppacket.decode()
-        next(decoder)
-
-        while True:
-            try:
-                b = await self._transport.readuntil()
-                decoder.send(b)
-            except StopIteration as e:
-                frame = e.value
-                break
+        frame = await self._transport.send_and_receive(request.BYTES)
 
         header = smpheader.Header.loads(frame[: smpheader.Header.SIZE])
 
@@ -51,37 +46,116 @@ class SMPClient:
             )
 
     async def upload(
-        self, image: bytes, slot: int = 0, chunksize: int = 2048, upgrade: bool = False
+        self, image: bytes, slot: int = 0, upgrade: bool = False
     ) -> AsyncIterator[int]:
         """Iteratively upload an `image` to `slot`, yielding the offset."""
 
+        if self._transport.max_unencoded_size < 23:
+            raise Exception("Upload requires an MTU >=23.")
+
+        def cbor_integer_size(integer: int) -> int:
+            """CBOR integers are packed as small as possible."""
+            return 0 if integer < 24 else 1 if integer < 0xFF else 2 if integer < 0xFFFF else 4
+
         # the first write contains some extra info
-        r = await self.request(
-            ImageUploadWrite(  # type: ignore
-                off=0,
-                data=image[:chunksize],
-                image=slot,
-                len=len(image),
-                sha=sha256(image).digest(),
-                upgrade=upgrade,
-            )
+
+        # create an empty request to see how much room is left for data
+        _r = ImageUploadWrite(
+            off=0,
+            data=b'',
+            image=slot,
+            len=len(image),
+            sha=sha256(image).digest(),
+            upgrade=upgrade,
+        )
+        _h = cast(smpheader.Header, _r.header)
+
+        chunk_size = self._transport.max_unencoded_size - len(bytes(_r))
+        chunk_size -= cbor_integer_size(chunk_size)
+        chunk_size = max(0, chunk_size)
+        cbor_size = _h.length + chunk_size + cbor_integer_size(chunk_size)
+
+        image_upload_write = ImageUploadWrite(
+            header=smpheader.Header(
+                op=_h.op,
+                version=_h.version,
+                flags=_h.flags,
+                length=cbor_size,
+                group_id=_h.group_id,
+                sequence=_h.sequence,
+                command_id=_h.command_id,
+            ),
+            off=0,
+            data=image[:chunk_size],
+            image=slot,
+            len=len(image),
+            sha=sha256(image).digest(),
+            upgrade=upgrade,
         )
 
-        if error(r):
-            raise SMPUploadError(r)
-        elif success(r):
-            yield r.off
+        response = await self.request(image_upload_write)  # type: ignore
+
+        if error(response):
+            raise SMPUploadError(response)
+        elif success(response):
+            yield response.off
         else:  # pragma: no cover
             raise Exception("Unreachable")
 
         # send chunks until the SMP server reports that the offset is at the end of the image
-        while r.off != len(image):
-            r = await self.request(
-                ImageUploadWrite(off=r.off, data=image[r.off : r.off + chunksize])
+        while response.off != len(image):
+            # create an empty request to see how much room is left for data
+            _r = ImageUploadWrite(off=response.off, data=b'')
+
+            chunk_size = self._transport.max_unencoded_size - len(bytes(_r))
+            chunk_size -= cbor_integer_size(chunk_size)
+            assert chunk_size > 0
+            cbor_size = _r.header.length + chunk_size + cbor_integer_size(chunk_size)
+
+            data = image[response.off : response.off + chunk_size]
+
+            cbor_size = (
+                cbor_size if len(data) == chunk_size else len(data) + cbor_integer_size(len(data))
             )
-            if error(r):
-                raise SMPUploadError(r)
-            elif success(r):
-                yield r.off
+
+            image_upload_write = ImageUploadWrite(
+                header=smpheader.Header(
+                    op=_r.header.op,
+                    version=_r.header.version,
+                    flags=_r.header.flags,
+                    length=cbor_size,
+                    group_id=_r.header.group_id,
+                    sequence=_r.header.sequence,
+                    command_id=_r.header.command_id,
+                ),
+                off=response.off,
+                data=data,
+            )
+
+            if (
+                len(bytes(image_upload_write)) + response.off <= len(image)
+                and len(bytes(image_upload_write)) != self._transport.max_unencoded_size
+            ):
+                raise Exception(
+                    f"{len(bytes(image_upload_write))} > {self._transport.max_unencoded_size}; "
+                    f"An upload write must fit in MTU, this is a bug!"
+                )
+
+            response = await self.request(image_upload_write)
+            if error(response):
+                raise SMPUploadError(response)
+            elif success(response):
+                yield response.off
             else:  # pragma: no cover
                 raise Exception("Unreachable")
+
+    @property
+    def address(self) -> str:
+        return self._address
+
+    async def __aenter__(self) -> 'SMPClient':
+        await self.connect()
+        return self
+
+    async def __aexit__(self) -> None:
+        await self.disconnect()

--- a/smpclient/transport/__init__.py
+++ b/smpclient/transport/__init__.py
@@ -5,13 +5,24 @@ from typing import Protocol
 
 class SMPTransport(Protocol):
     async def connect(self, address: str) -> None:  # pragma: no cover
-        ...
+        """Connect the `SMPTransport`."""
+
+    async def disconnect(self) -> None:  # pragma: no cover
+        """Disconnect the `SMPTransport`."""
 
     async def send(self, data: bytes) -> None:  # pragma: no cover
-        ...
+        """Send the encoded `SMPRequest` `data`."""
 
-    def write(self, data: bytes) -> None:  # pragma: no cover
-        ...
+    async def receive(self) -> bytes:  # pragma: no cover
+        """Receive the decoded `SMPResponse`."""
 
-    async def readuntil(self, delimiter: bytes = b"\n") -> bytes:  # pragma: no cover
-        ...
+    async def send_and_receive(self, data: bytes) -> bytes:  # pragma: no cover
+        """Send the encoded `SMPRequest` `data` and receive the decoded `SMPResponse`."""
+
+    @property
+    def mtu(self) -> int:  # pragma: no cover
+        """The Maximum Transmission Unit (MTU) in 8-bit bytes."""
+
+    @property
+    def max_unencoded_size(self) -> int:  # pragma: no cover
+        """The maximum size of an unencoded message that can be sent in one MTU, in 8-bit bytes."""

--- a/smpclient/transport/ble.py
+++ b/smpclient/transport/ble.py
@@ -1,0 +1,137 @@
+"""A Bluetooth Low Energy (BLE) SMPTransport."""
+
+import asyncio
+import logging
+import re
+from typing import Final
+from uuid import UUID
+
+from bleak import BleakClient, BleakGATTCharacteristic, BleakScanner
+from bleak.backends.device import BLEDevice
+from smp import header as smphdr
+
+from smpclient.exceptions import SMPClientException
+
+SMP_SERVICE_UUID: Final = UUID("8D53DC1D-1DB7-4CD3-868B-8A527460AA84")
+SMP_CHARACTERISTIC_UUID: Final = UUID("DA2E7828-FBCE-4E01-AE9E-261174997C48")
+
+MAC_ADDRESS_PATTERN: Final = re.compile(r'([0-9A-F]{2}[:]){5}[0-9A-F]{2}$', flags=re.IGNORECASE)
+UUID_PATTERN: Final = re.compile(
+    r'^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}\Z',
+    flags=re.IGNORECASE,
+)
+
+
+class SMPBLETransportException(SMPClientException):
+    ...
+
+
+class SMPBLETransportDeviceNotFound(SMPBLETransportException):
+    ...
+
+
+class SMPBLETransportNotSMPServer(SMPBLETransportException):
+    ...
+
+
+logger = logging.getLogger(__name__)
+
+
+class SMPBLETransport:
+    def __init__(self) -> None:
+        self._buffer = bytearray()
+        self._notify_condition = asyncio.Condition()
+        logger.debug(f"Initialized {self.__class__.__name__}")
+
+    async def connect(self, address: str) -> None:
+        logger.debug(f"Scanning for {address=}")
+        device = (
+            await BleakScanner.find_device_by_address(address)  # type: ignore # upstream fix
+            if MAC_ADDRESS_PATTERN.match(address) or UUID_PATTERN.match(address)
+            else await BleakScanner.find_device_by_name(address)  # type: ignore # upstream fix
+        )
+
+        if type(device) is BLEDevice:
+            self._client = BleakClient(device, services=(str(SMP_SERVICE_UUID),))
+        else:
+            raise SMPBLETransportDeviceNotFound(f"Device '{address}' not found")
+
+        logger.debug(f"Found device: {device=}, connecting...")
+        await self._client.connect()
+        logger.debug(f"Connected to {device=}")
+
+        smp_characteristic = self._client.services.get_characteristic(SMP_CHARACTERISTIC_UUID)
+        if smp_characteristic is None:
+            raise SMPBLETransportNotSMPServer("Missing the SMP characteristic UUID.")
+        else:
+            self._smp_characteristic = smp_characteristic
+
+        logger.debug(f"Starting notify on {SMP_CHARACTERISTIC_UUID=}")
+        await self._client.start_notify(SMP_CHARACTERISTIC_UUID, self._notify_callback)
+        logger.debug(f"Started notify on {SMP_CHARACTERISTIC_UUID=}")
+
+    async def disconnect(self) -> None:
+        logger.debug(f"Disonnecting from {self._client.address}")
+        await self._client.disconnect()
+        logger.debug(f"Disconnected from {self._client.address}")
+
+    async def send(self, data: bytes) -> None:
+        # TODO: Unclear whether Bleak + SMP spec support transport-level fragmentation.  We can
+        #       continue this manual fragmentation for now, but it is not ideal.
+
+        logger.debug(f"Sending {len(data)} bytes, {self.mtu=}")
+        for offset in range(0, len(data), self.mtu):
+            await self._client.write_gatt_char(
+                self._smp_characteristic, data[offset : offset + self.mtu], response=False
+            )
+        logger.debug(f"Sent {len(data)} bytes")
+
+    async def receive(self) -> bytes:
+        # Note: self._buffer is mutated asynchronously by this method and self._notify_callback().
+        #       self._notify_condition is used to synchronize access to self._buffer.
+
+        async with self._notify_condition:  # wait for the header
+            logger.debug(f"Waiting for notify on {SMP_CHARACTERISTIC_UUID=}")
+            await self._notify_condition.wait()
+
+            if len(self._buffer) < smphdr.Header.SIZE:  # pragma: no cover
+                raise SMPBLETransportException(
+                    f"Buffer contents not big enough for SMP header: {self._buffer=}"
+                )
+
+            header: Final = smphdr.Header.loads(self._buffer[: smphdr.Header.SIZE])
+            logger.debug(f"Received {header=}")
+
+        message_length: Final = header.length + header.SIZE
+        logger.debug(f"Waiting for the rest of the {message_length} byte response")
+
+        while True:  # wait for the rest of the message
+            async with self._notify_condition:
+                if len(self._buffer) == message_length:
+                    logger.debug(f"Finished receiving {message_length} byte response")
+                    out = bytes(self._buffer)
+                    self._buffer.clear()
+                    return out
+                elif len(self._buffer) > message_length:  # pragma: no cover
+                    raise SMPBLETransportException("Length of buffer passed expected message size.")
+                await self._notify_condition.wait()
+
+    async def _notify_callback(self, sender: BleakGATTCharacteristic, data: bytes) -> None:
+        if sender.uuid != str(SMP_CHARACTERISTIC_UUID):  # pragma: no cover
+            raise SMPBLETransportException(f"Unexpected notify from {sender}; {data=}")
+        async with self._notify_condition:
+            logger.debug(f"Received {len(data)} bytes from {SMP_CHARACTERISTIC_UUID=}")
+            self._buffer.extend(data)
+            self._notify_condition.notify()
+
+    async def send_and_receive(self, data: bytes) -> bytes:
+        await self.send(data)
+        return await self.receive()
+
+    @property
+    def mtu(self) -> int:
+        return self._smp_characteristic.max_write_without_response_size
+
+    @property
+    def max_unencoded_size(self) -> int:
+        return self.mtu

--- a/smpclient/transport/serial.py
+++ b/smpclient/transport/serial.py
@@ -1,8 +1,30 @@
 """A serial SMPTransport."""
 
 import asyncio
+import math
+from functools import cached_property
+from typing import Final
 
-from serial import Serial  # type: ignore
+from serial import Serial
+from smp import packet as smppacket
+
+
+def _base64_cost(size: int) -> int:
+    """The worst case size required to encode `size` `bytes`."""
+
+    if size == 0:
+        return 0
+
+    return math.ceil(4 / 3 * size) + 2
+
+
+def _base64_max(size: int) -> int:
+    """Given a max `size`, return how many bytes can be encoded."""
+
+    if size < 4:
+        return 0
+
+    return math.floor(3 / 4 * size) - 2
 
 
 class SMPSerialTransport:
@@ -10,6 +32,7 @@ class SMPSerialTransport:
 
     def __init__(
         self,
+        mtu: int = 4096,
         baudrate: int = 115200,
         bytesize: int = 8,
         parity: str = "N",
@@ -22,7 +45,8 @@ class SMPSerialTransport:
         inter_byte_timeout: float | None = None,
         exclusive: float | None = None,
     ) -> None:
-        self._conn = Serial(
+        self._mtu: Final = mtu
+        self._conn: Final = Serial(
             baudrate=baudrate,
             bytesize=bytesize,
             parity=parity,
@@ -41,32 +65,87 @@ class SMPSerialTransport:
         self._conn.port = address
         self._conn.open()
 
-    def write(self, data: bytes) -> None:
-        self._conn.write(data)
+    async def disconnect(self) -> None:
+        self._conn.close()
 
     async def send(self, data: bytes) -> None:
-        self.write(data)
+        for packet in smppacket.encode(data, line_length=self.max_unencoded_size):
+            if len(packet) > self.mtu:  # pragma: no cover
+                raise Exception(
+                    f"Encoded packet size {len(packet)} exceeds {self.mtu=}, this is a bug!"
+                )
+            self._conn.write(packet)
 
         # fake async until I get around to replacing pyserial
         while self._conn.out_waiting > 0:
             await asyncio.sleep(SMPSerialTransport._POLLING_INTERVAL_S)
 
-    async def readuntil(self, delimiter: bytes = b"\n") -> bytes:
+    async def receive(self) -> bytes:
+        decoder = smppacket.decode()
+        next(decoder)
+
+        while True:
+            try:
+                b = await self._readuntil()
+                decoder.send(b)
+            except StopIteration as e:
+                return e.value
+
+    async def _readuntil(self, delimiter: bytes = b"\n") -> bytes:
+        """Read `bytes` until the `delimiter` then return the `bytes` including the `delimiter`."""
+
         # fake async until I get around to replacing pyserial
+
+        i = 0
         while True:
             # read the entire OS buffer
-            self._buffer.extend(self._conn.read_all())
+            self._buffer.extend(self._conn.read_all() or [])
 
-            # iterate the whole buffer to check for the delimiter
-            for i in range(0, len(self._buffer) - (len(delimiter) - 1)):
-                if self._buffer[i : i + len(delimiter)] == delimiter:
-                    # out is everything up to the delimiter
-                    out = self._buffer[: i + len(delimiter)]
+            try:  # search the buffer for the index of the delimiter
+                i = self._buffer.index(delimiter, i) + len(delimiter)
 
-                    # there may be some leftover to save for the next read
-                    self._buffer = self._buffer[i + len(delimiter) :]
+                # out is everything up to and including the delimiter
+                out = self._buffer[:i]
 
-                    return out
+                # there may be some leftover to save for the next read
+                self._buffer = self._buffer[i:]
 
-            # delimiter was not reached, save the buffer and wait
-            await asyncio.sleep(SMPSerialTransport._POLLING_INTERVAL_S)
+                return out
+
+            except ValueError:  # delimiter not found yet, wait
+                await asyncio.sleep(SMPSerialTransport._POLLING_INTERVAL_S)
+
+    async def send_and_receive(self, data: bytes) -> bytes:
+        await self.send(data)
+        return await self.receive()
+
+    @property
+    def mtu(self) -> int:
+        return self._mtu
+
+    @cached_property
+    def max_unencoded_size(self) -> int:
+        """The serial transport encodes each packet instead of sending SMP messages as raw bytes.
+
+        The worst case size of an encoded SMP packet is:
+        ```
+        base64_cost(
+            len(smp_message) + len(frame_length) + len(frame_crc16)
+        ) + len(delimiter) + len(line_ending)
+        ```
+        This simplifies to:
+        ```
+        base64_cost(len(smp_message) + 4) + 3
+        ```
+
+        This property specifies the maximum size of an SMP message before it has been encoded for
+        the serial transport.
+        """
+
+        packet_framing_size: Final = (
+            _base64_cost(smppacket.FRAME_LENGTH_STRUCT.size + smppacket.CRC16_STRUCT.size)
+            + smppacket.DELIMITER_SIZE
+            + len(smppacket.CR)
+        )
+
+        return _base64_max(self.mtu) - packet_framing_size

--- a/tests/test_base64.py
+++ b/tests/test_base64.py
@@ -1,0 +1,18 @@
+"""Test the base64 helpers."""
+
+import random
+from base64 import b64encode
+
+from smpclient.transport.serial import _base64_cost, _base64_max
+
+
+def test_base64_sizing() -> None:
+    """Assert that `_base64_max` is always within 4 of encoded size."""
+
+    random.seed(1)
+
+    for size in range(1, 0xFFFF):
+        assert 0 <= size - _base64_cost(_base64_max(size)) < 4
+        data = random.randbytes(_base64_max(size))
+        encoded = b64encode(data)
+        assert 0 <= size - len(encoded) < 4

--- a/tests/test_smp_ble_transport.py
+++ b/tests/test_smp_ble_transport.py
@@ -32,10 +32,6 @@ def test_MAC_ADDRESS_PATTERN() -> None:
     assert MAC_ADDRESS_PATTERN.match("FF:FF:FF:FF:FF:FF")
     assert MAC_ADDRESS_PATTERN.match("00:FF:00:FF:00:FF")
     assert MAC_ADDRESS_PATTERN.match("FF:00:FF:00:FF:00")
-    assert MAC_ADDRESS_PATTERN.match("00:00:00:00:00:00")
-    assert MAC_ADDRESS_PATTERN.match("FF:FF:FF:FF:FF:FF")
-    assert MAC_ADDRESS_PATTERN.match("00:FF:00:FF:00:FF")
-    assert MAC_ADDRESS_PATTERN.match("FF:00:FF:00:FF:00")
 
     assert not MAC_ADDRESS_PATTERN.match("00:00:00:00:00")
     assert not MAC_ADDRESS_PATTERN.match("00:00:00:00:00:00:00")

--- a/tests/test_smp_ble_transport.py
+++ b/tests/test_smp_ble_transport.py
@@ -1,0 +1,199 @@
+"""Tests for `SMPBLETransport`."""
+
+import asyncio
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from bleak import BleakClient, BleakGATTCharacteristic
+from bleak.backends.device import BLEDevice
+
+from smpclient.requests.os_management import EchoWrite
+from smpclient.transport.ble import (
+    MAC_ADDRESS_PATTERN,
+    SMP_CHARACTERISTIC_UUID,
+    SMP_SERVICE_UUID,
+    UUID_PATTERN,
+    SMPBLETransport,
+    SMPBLETransportDeviceNotFound,
+    SMPBLETransportNotSMPServer,
+)
+
+
+def test_constructor() -> None:
+    t = SMPBLETransport()
+    assert t._buffer == bytearray()
+    assert isinstance(t._notify_condition, asyncio.Condition)
+
+
+def test_MAC_ADDRESS_PATTERN() -> None:
+    assert MAC_ADDRESS_PATTERN.match("00:00:00:00:00:00")
+    assert MAC_ADDRESS_PATTERN.match("FF:FF:FF:FF:FF:FF")
+    assert MAC_ADDRESS_PATTERN.match("00:FF:00:FF:00:FF")
+    assert MAC_ADDRESS_PATTERN.match("FF:00:FF:00:FF:00")
+    assert MAC_ADDRESS_PATTERN.match("00:00:00:00:00:00")
+    assert MAC_ADDRESS_PATTERN.match("FF:FF:FF:FF:FF:FF")
+    assert MAC_ADDRESS_PATTERN.match("00:FF:00:FF:00:FF")
+    assert MAC_ADDRESS_PATTERN.match("FF:00:FF:00:FF:00")
+
+    assert not MAC_ADDRESS_PATTERN.match("00:00:00:00:00")
+    assert not MAC_ADDRESS_PATTERN.match("00:00:00:00:00:00:00")
+    assert not MAC_ADDRESS_PATTERN.match("00:00:00:00:00:00:00:00")
+    assert not MAC_ADDRESS_PATTERN.match("00:00:00:00:00:00:00:00:00")
+    assert not MAC_ADDRESS_PATTERN.match("00:00:00:00:00:0G")
+    assert not MAC_ADDRESS_PATTERN.match("00:00:00:00:00:00:0G")
+    assert not MAC_ADDRESS_PATTERN.match("00:00:00:00:00:00:00:0G")
+    assert not MAC_ADDRESS_PATTERN.match("00:00:00:00:00:00:00:00:0G")
+
+
+def test_UUID_PATTERN() -> None:
+    assert UUID_PATTERN.match("00000000-0000-4000-8000-000000000000")
+    assert UUID_PATTERN.match("FFFFFFFF-FFFF-4FFF-9FFF-FFFFFFFFFFFF")
+    assert UUID_PATTERN.match("0000FFFF-0000-4FFF-a000-FFFFFFFFFFFF")
+    assert UUID_PATTERN.match("FFFF0000-FFFF-4000-bFFF-000000000000")
+
+    assert UUID_PATTERN.match(UUID("00000000-0000-4000-8000-000000000000").hex)
+    assert UUID_PATTERN.match(UUID("FFFFFFFF-FFFF-4FFF-9FFF-FFFFFFFFFFFF").hex)
+    assert UUID_PATTERN.match(UUID("0000FFFF-0000-4FFF-a000-FFFFFFFFFFFF").hex)
+    assert UUID_PATTERN.match(UUID("FFFF0000-FFFF-4000-bFFF-000000000000").hex)
+
+    assert not UUID_PATTERN.match("00000000-0000-0000-8000-000000000000")
+    assert not UUID_PATTERN.match("FFFFFFFF-FFFF-1FFF-9FFF-FFFFFFFFFFFF")
+    assert not UUID_PATTERN.match("0000FFFF-0000-4FFF-c000-FFFFFFFFFFFF")
+    assert not UUID_PATTERN.match("FFFF0000-FFFF-4000-dFFF-000000000000")
+
+
+def test_SMP_gatt_consts() -> None:
+    assert SMP_CHARACTERISTIC_UUID == UUID("DA2E7828-FBCE-4E01-AE9E-261174997C48")
+    assert SMP_SERVICE_UUID == UUID("8D53DC1D-1DB7-4CD3-868B-8A527460AA84")
+
+
+@patch(
+    "smpclient.transport.ble.BleakScanner.find_device_by_address",
+    return_value=BLEDevice("address", "name", None, -60),
+)
+@patch(
+    "smpclient.transport.ble.BleakScanner.find_device_by_name",
+    return_value=BLEDevice("address", "name", None, -60),
+)
+@patch("smpclient.transport.ble.BleakClient", autospec=True)
+@pytest.mark.asyncio
+async def test_connect(
+    _: MagicMock,
+    mock_find_device_by_name: MagicMock,
+    mock_find_device_by_address: MagicMock,
+) -> None:
+    # assert that it searches by name if MAC or UUID is not provided
+    await SMPBLETransport().connect("device name")
+    mock_find_device_by_name.assert_called_once_with("device name")
+    mock_find_device_by_name.reset_mock()
+
+    # assert that it searches by MAC if MAC is provided
+    await SMPBLETransport().connect("00:00:00:00:00:00")
+    mock_find_device_by_address.assert_called_once_with("00:00:00:00:00:00")
+    mock_find_device_by_address.reset_mock()
+
+    # assert that it searches by UUID if UUID is provided
+    await SMPBLETransport().connect(UUID("00000000-0000-4000-8000-000000000000").hex)
+    mock_find_device_by_address.assert_called_once_with("00000000000040008000000000000000")
+    mock_find_device_by_address.reset_mock()
+
+    # assert that it raises an exception if the device is not found
+    mock_find_device_by_address.return_value = None
+    with pytest.raises(SMPBLETransportDeviceNotFound):
+        await SMPBLETransport().connect("00:00:00:00:00:00")
+    mock_find_device_by_address.reset_mock()
+
+    # assert that connect is awaited
+    t = SMPBLETransport()
+    await t.connect("name")
+    t._client = cast(MagicMock, t._client)  # type: ignore
+    t._client.reset_mock()
+    await t.connect("name")
+    t._client.connect.assert_awaited_once_with()
+
+    # assert that the SMP characteristic is checked
+    t._client.services.get_characteristic.assert_called_once_with(SMP_CHARACTERISTIC_UUID)
+
+    # assert that an exception is raised if the SMP characteristic is not found
+    t._client.services.get_characteristic.return_value = None
+    with pytest.raises(SMPBLETransportNotSMPServer):
+        await t.connect("name")
+    t._client.reset_mock()
+
+    # assert that the SMP characteristic is saved
+    m = MagicMock()
+    t._client.services.get_characteristic.return_value = m
+    await t.connect("name")
+    assert t._smp_characteristic is m
+
+    # assert that SMP characteristic notifications are started
+    t._client.start_notify.assert_called_once_with(SMP_CHARACTERISTIC_UUID, t._notify_callback)
+
+
+@pytest.mark.asyncio
+async def test_disconnect() -> None:
+    t = SMPBLETransport()
+    t._client = MagicMock(spec=BleakClient)
+    await t.disconnect()
+    t._client.disconnect.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_send() -> None:
+    t = SMPBLETransport()
+    t._client = MagicMock(spec=BleakClient)
+    t._smp_characteristic = MagicMock(spec=BleakGATTCharacteristic)
+    t._smp_characteristic.max_write_without_response_size = 20
+    await t.send(b"Hello pytest!")
+    t._client.write_gatt_char.assert_awaited_once_with(
+        t._smp_characteristic, b"Hello pytest!", response=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_receive() -> None:
+    t = SMPBLETransport()
+    t._client = MagicMock(spec=BleakClient)
+    t._smp_characteristic = MagicMock(spec=BleakGATTCharacteristic)
+    t._smp_characteristic.uuid = str(SMP_CHARACTERISTIC_UUID)
+
+    REP = EchoWrite.Response(sequence=0, r="Hello pytest!").BYTES
+
+    b, _ = await asyncio.gather(
+        t.receive(),
+        t._notify_callback(t._smp_characteristic, REP),
+    )
+
+    assert b == REP
+
+    # cool, now try with a fragmented response
+    async def fragmented_notifies() -> None:
+        await t._notify_callback(t._smp_characteristic, REP[:10])
+        await asyncio.sleep(0.001)
+        await t._notify_callback(t._smp_characteristic, REP[10:])
+
+    b, _ = await asyncio.gather(
+        t.receive(),
+        fragmented_notifies(),
+    )
+
+    assert b == REP
+
+
+@pytest.mark.asyncio
+async def test_send_and_receive() -> None:
+    t = SMPBLETransport()
+    t.send = AsyncMock()  # type: ignore
+    t.receive = AsyncMock()  # type: ignore
+    await t.send_and_receive(b"Hello pytest!")
+    t.send.assert_awaited_once_with(b"Hello pytest!")
+    t.receive.assert_awaited_once_with()
+
+
+def test_max_unencoded_size() -> None:
+    t = SMPBLETransport()
+    t._smp_characteristic = MagicMock(spec=BleakGATTCharacteristic)
+    t._smp_characteristic.max_write_without_response_size = 20
+    assert t.max_unencoded_size == 20

--- a/tests/test_smp_client.py
+++ b/tests/test_smp_client.py
@@ -210,7 +210,6 @@ async def test_upload_hello_world_bin(
     s.request = mock_request  # type: ignore
 
     async for _ in s.upload(image):
-        print(_)
         pass
 
     assert accumulated_image == image

--- a/tests/test_smp_client.py
+++ b/tests/test_smp_client.py
@@ -1,14 +1,20 @@
 """Tests for `SMPClient`."""
 
 from hashlib import sha256
-from typing import cast
-from unittest.mock import AsyncMock, MagicMock, call
+from pathlib import Path
+from typing import List, cast
+from unittest.mock import AsyncMock, PropertyMock, call, patch
 
 import pytest
 from smp import header as smphdr
 from smp import packet as smppacket
 from smp.error import Err as SMPErr
-from smp.image_management import IMG_MGMT_ERR, ImageManagementErrorV0, ImageManagementErrorV1
+from smp.image_management import (
+    IMG_MGMT_ERR,
+    ImageManagementErrorV0,
+    ImageManagementErrorV1,
+    ImageUploadWriteRequest,
+)
 from smp.os_management import OS_MGMT_RET_RC, OSManagementErrorV0, ResetWriteResponse
 
 from smpclient import SMPClient
@@ -16,14 +22,23 @@ from smpclient.exceptions import SMPBadSequence, SMPUploadError
 from smpclient.generics import error, success
 from smpclient.requests.image_management import ImageUploadWrite
 from smpclient.requests.os_management import ResetWrite
+from smpclient.transport.serial import SMPSerialTransport
 
 
 class SMPMockTransport:
+    """Satisfies the `SMPTransport` `Protocol`."""
+
     def __init__(self) -> None:
         self.connect = AsyncMock()
+        self.disconnect = AsyncMock()
         self.send = AsyncMock()
-        self.write = MagicMock()
-        self.readuntil = AsyncMock()
+        self.receive = AsyncMock()
+        self.mtu = PropertyMock()
+        self.max_unencoded_size = PropertyMock()
+
+    async def send_and_receive(self, data: bytes) -> bytes:
+        await self.send(data)
+        return await self.receive()
 
 
 def test_constructor() -> None:
@@ -48,41 +63,31 @@ async def test_request() -> None:
     s = SMPClient(m, "address")
 
     req = ResetWrite()
-    m.readuntil.return_value = [
-        p for p in smppacket.encode(ResetWriteResponse(sequence=req.header.sequence).BYTES)  # type: ignore # noqa
-    ][0]
+    m.receive.return_value = ResetWriteResponse(sequence=req.header.sequence).BYTES  # type: ignore # noqa
     rep = await s.request(req)  # type: ignore
-    packets = [call(p) for p in smppacket.encode(req.BYTES)]
-    m.send.assert_has_awaits(packets)
-    m.readuntil.assert_awaited()
+    m.send.assert_has_awaits([call(req.BYTES)])
+    m.receive.assert_awaited()
     assert type(rep) is req.Response
     assert success(rep) is True
     assert error(rep) is False
 
     # test that a bad sequence raises `SMPBadSequence`
     req = ResetWrite()
-    m.readuntil.return_value = [
-        p for p in smppacket.encode(ResetWriteResponse(sequence=req.header.sequence + 1).BYTES)
-    ][0]
+    m.receive.return_value = ResetWriteResponse(sequence=req.header.sequence + 1).BYTES
     with pytest.raises(SMPBadSequence):
         await s.request(req)  # type: ignore
 
     # test that an error response is parsed
     req = ResetWrite()
-    m.readuntil.return_value = [
-        p
-        for p in smppacket.encode(
-            OSManagementErrorV0(
-                header=ResetWriteResponse(sequence=req.header.sequence).header,
-                sequence=req.header.sequence,
-                rc=OS_MGMT_RET_RC.UNKNOWN,
-            ).BYTES
-        )
-    ][0]
+    m.receive.return_value = OSManagementErrorV0(
+        header=ResetWriteResponse(sequence=req.header.sequence).header,
+        sequence=req.header.sequence,
+        rc=OS_MGMT_RET_RC.UNKNOWN,
+    ).BYTES
+
     rep = await s.request(req)  # type: ignore
-    packets = [call(p) for p in smppacket.encode(req.BYTES)]
-    m.send.assert_has_awaits(packets)
-    m.readuntil.assert_awaited()
+    m.send.assert_has_awaits([call(req.BYTES)])
+    m.receive.assert_awaited()
     assert rep.rc == OS_MGMT_RET_RC.UNKNOWN
     assert success(rep) is False
     assert error(rep) is True
@@ -95,10 +100,16 @@ async def test_upload() -> None:
 
     s.request = AsyncMock()  # type: ignore
 
+    # refer to: https://docs.python.org/3/library/unittest.mock.html#unittest.mock.PropertyMock
+    type(m).mtu = PropertyMock(return_value=498)
+    type(m).max_unencoded_size = PropertyMock(return_value=498)
+
+    chunk_size = 415  # max chunk given MTU
+
     image = bytes([i % 255 for i in range(4097)])
     req = ImageUploadWrite(
         off=0,
-        data=image[:2048],
+        data=image[:chunk_size],
         image=0,
         len=len(image),
         sha=sha256(image).digest(),
@@ -108,9 +119,9 @@ async def test_upload() -> None:
     u = s.upload(image)
     h = cast(smphdr.Header, req.header)
 
-    s.request.return_value = ImageUploadWrite.Response(off=2048)
+    s.request.return_value = ImageUploadWrite.Response(off=415)
     offset = await anext(u)
-    assert offset == 2048
+    assert offset == 415
     s.request.assert_awaited_once_with(
         ImageUploadWrite(
             header=smphdr.Header(
@@ -123,7 +134,7 @@ async def test_upload() -> None:
                 command_id=h.command_id,
             ),
             off=0,
-            data=image[:2048],
+            data=image[:chunk_size],
             image=0,
             len=len(image),
             sha=sha256(image).digest(),
@@ -131,22 +142,22 @@ async def test_upload() -> None:
         )
     )
 
-    s.request.return_value = ImageUploadWrite.Response(off=2049)
+    s.request.return_value = ImageUploadWrite.Response(off=415 + 474)
     offset = await anext(u)
-    assert offset == 2049
+    assert offset == 415 + 474
     s.request.assert_awaited_with(
         ImageUploadWrite(
             header=smphdr.Header(
                 op=h.op,
                 version=h.version,
                 flags=h.flags,
-                length=2064,
+                length=h.length,
                 group_id=h.group_id,
                 sequence=h.sequence + 2,
                 command_id=h.command_id,
             ),
-            off=2048,
-            data=image[2048:4096],
+            off=415,
+            data=image[415 : 415 + 474],
         )
     )
 
@@ -169,3 +180,98 @@ async def test_upload() -> None:
     with pytest.raises(SMPUploadError) as e:
         _ = await anext(u)
     assert e.value.args[0].err.rc == IMG_MGMT_ERR.FLASH_WRITE_FAILED
+
+
+@patch('tests.test_smp_client.SMPMockTransport.mtu', new_callable=PropertyMock)
+@patch('tests.test_smp_client.SMPMockTransport.max_unencoded_size', new_callable=PropertyMock)
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mtu", [23, 124, 127, 251, 498, 512, 1024, 2048, 4096, 8192])
+async def test_upload_hello_world_bin(
+    mock_mtu: PropertyMock, mock_max_unencoded_size: PropertyMock, mtu: int
+) -> None:
+    mock_mtu.return_value = mtu
+    mock_max_unencoded_size.return_value = mtu
+
+    with open(
+        str(Path("tests", "fixtures", "zephyr-v3.5.0-2795-g28ff83515d", "hello_world.signed.bin")),
+        'rb',
+    ) as f:
+        image = f.read()
+
+    m = SMPMockTransport()
+    s = SMPClient(m, "address")
+
+    accumulated_image = bytearray([])
+
+    async def mock_request(request: ImageUploadWrite) -> ImageUploadWrite.Response:
+        accumulated_image.extend(request.data)
+        return ImageUploadWrite.Response(off=request.off + len(request.data))
+
+    s.request = mock_request  # type: ignore
+
+    async for _ in s.upload(image):
+        print(_)
+        pass
+
+    assert accumulated_image == image
+
+
+@patch('tests.test_smp_client.SMPSerialTransport.mtu', new_callable=PropertyMock)
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mtu", [48, 80, 124, 127, 256, 512, 1024, 2048, 4096, 8192])
+async def test_upload_hello_world_bin_encoded(mock_mtu: PropertyMock, mtu: int) -> None:
+    mock_mtu.return_value = mtu
+
+    with open(
+        str(Path("tests", "fixtures", "zephyr-v3.5.0-2795-g28ff83515d", "hello_world.signed.bin")),
+        'rb',
+    ) as f:
+        image = f.read()
+
+    m = SMPSerialTransport()
+    s = SMPClient(m, "address")
+
+    packets: List[bytes] = []
+
+    def mock_write(data: bytes) -> int:
+        """Accumulate the raw packets in the global `packets`."""
+        packets.append(data)
+        return len(data)
+
+    s._transport._conn.write = mock_write  # type: ignore
+    type(s._transport._conn).out_waiting = 0  # type: ignore
+
+    async def mock_request(request: ImageUploadWrite) -> ImageUploadWrite.Response:
+        # call the real send method (with write mocked) but don't bother with receive
+        # this does provide coverage for the MTU-limited encoding done in the send method
+        await s._transport.send(request.BYTES)
+        return ImageUploadWrite.Response(off=request.off + len(request.data))
+
+    s.request = mock_request  # type: ignore
+
+    # refer to: https://docs.python.org/3/library/unittest.mock.html#unittest.mock.PropertyMock
+    # type(m).mtu = PropertyMock(return_value=mtu)  # type: ignore
+
+    assert (
+        s._transport.max_unencoded_size < s._transport.mtu
+    ), "The serial transport has encoding overhead"
+
+    async for _ in s.upload(image):
+        pass
+
+    reconstructed_image = bytearray([])
+
+    decoder = smppacket.decode()
+    next(decoder)
+
+    for packet in packets:
+        try:
+            decoder.send(packet)
+        except StopIteration as e:
+            reconstructed_request = ImageUploadWriteRequest.loads(e.value)
+            reconstructed_image.extend(reconstructed_request.data)
+
+            decoder = smppacket.decode()
+            next(decoder)
+
+    assert reconstructed_image == image

--- a/tests/test_smp_serial_transport.py
+++ b/tests/test_smp_serial_transport.py
@@ -1,8 +1,139 @@
 """Tests for `SMPSerialTransport`."""
 
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
+import pytest
+from serial import Serial
+from smp import packet as smppacket
+
+from smpclient.requests.os_management import EchoWrite
 from smpclient.transport.serial import SMPSerialTransport
 
 
 def test_constructor() -> None:
-    SMPSerialTransport()
+    t = SMPSerialTransport()
+    assert isinstance(t._conn, Serial)
+
+    t = SMPSerialTransport(mtu=512)
+    assert isinstance(t._conn, Serial)
+    assert t.mtu == 512
+    assert t.max_unencoded_size < 512
+
+
+@patch("smpclient.transport.serial.Serial")
+@pytest.mark.asyncio
+async def test_connect(_: MagicMock) -> None:
+    t = SMPSerialTransport()
+
+    await t.connect("COM2")
+    assert t._conn.port == "COM2"
+
+    t._conn.open.assert_called_once()  # type: ignore
+
+    t._conn.reset_mock()  # type: ignore
+
+    t = SMPSerialTransport()
+
+    await t.connect("/dev/ttyACM0")
+    assert t._conn.port == "/dev/ttyACM0"
+
+    t._conn.open.assert_called_once()  # type: ignore
+
+
+@patch("smpclient.transport.serial.Serial")
+@pytest.mark.asyncio
+async def test_disconnect(_: MagicMock) -> None:
+    t = SMPSerialTransport()
+    await t.disconnect()
+    t._conn.close.assert_called_once()  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_send() -> None:
+    t = SMPSerialTransport()
+    t._conn.write = MagicMock()  # type: ignore
+    p = PropertyMock(return_value=0)
+    type(t._conn).out_waiting = p  # type: ignore
+
+    r = EchoWrite(d="Hello pytest!")
+    await t.send(r.BYTES)
+    t._conn.write.assert_called_once()  # type: ignore
+    p.assert_called_once_with()
+
+    t._conn.write.reset_mock()
+    p = PropertyMock(side_effect=(1, 0))
+    type(t._conn).out_waiting = p  # type: ignore
+
+    await t.send(r.BYTES)
+    t._conn.write.assert_called_once()  # type: ignore
+    assert p.call_count == 2  # called twice since out buffer was not drained on first call
+
+
+@pytest.mark.asyncio
+async def test_receive() -> None:
+    t = SMPSerialTransport()
+    m = EchoWrite.Response(sequence=0, r="Hello pytest!")
+    p = [p for p in smppacket.encode(m.BYTES, t.max_unencoded_size)]
+    t._readuntil = AsyncMock(side_effect=p)  # type: ignore
+
+    b = await t.receive()
+    t._readuntil.assert_awaited_once_with()
+    assert b == m.BYTES
+
+    p = [p for p in smppacket.encode(m.BYTES, 8)]  # test packet fragmentation
+    t._readuntil = AsyncMock(side_effect=p)  # type: ignore
+
+    b = await t.receive()
+    t._readuntil.assert_awaited()
+    assert b == m.BYTES
+
+
+@pytest.mark.asyncio
+async def test_readuntil() -> None:
+    t = SMPSerialTransport()
+    m1 = EchoWrite.Response(sequence=0, r="Hello pytest!")
+    m2 = EchoWrite.Response(sequence=1, r="Hello computer!")
+    p1 = [p for p in smppacket.encode(m1.BYTES, 8)]
+    p2 = [p for p in smppacket.encode(m2.BYTES, 8)]
+    packets = p1 + p2
+    t._conn.read_all = MagicMock(side_effect=packets)  # type: ignore
+
+    for p in packets:
+        assert p == await t._readuntil()
+
+    # do again, but manually fragment the buffers
+    packets = [p for p in smppacket.encode(m1.BYTES, 512)] + [
+        p for p in smppacket.encode(m2.BYTES, 512)
+    ]
+    assert len(packets) == 2
+    buffers = [
+        packets[0][0:3],
+        packets[0][3:5],
+        packets[0][5:12],
+        packets[0][12:] + packets[1][0:3],
+        packets[1][3:5],
+        packets[1][5:12],
+        packets[1][12:],
+    ]
+
+    t._conn.read_all = MagicMock(side_effect=buffers)  # type: ignore
+
+    for p in packets:
+        assert p == await t._readuntil()
+
+
+@pytest.mark.asyncio
+async def test_send_and_receive() -> None:
+    t = SMPSerialTransport()
+    t.send = AsyncMock()  # type: ignore
+    t.receive = AsyncMock()  # type: ignore
+
+    await t.send_and_receive(b"some data")
+
+    t.send.assert_awaited_once_with(b"some data")
+    t.receive.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_upload() -> None:
+    pass

--- a/tests/test_smp_serial_transport.py
+++ b/tests/test_smp_serial_transport.py
@@ -132,8 +132,3 @@ async def test_send_and_receive() -> None:
 
     t.send.assert_awaited_once_with(b"some data")
     t.receive.assert_awaited_once_with()
-
-
-@pytest.mark.asyncio
-async def test_upload() -> None:
-    pass


### PR DESCRIPTION
OK, well, it was supposed to be just the addition of the BLE transport.  And if you look at that file, hey, it's an OK PR size!

There were some problems.  First, I learned that the BLE transport does not do the SMP encoding like the serial transport does.  So I've made encoding/decoding the responsibility of the transport object rather than the main SMPClient object.  This led me down an annoying path of trying to maximize the size of packets sent over the serial transport.  Hopefully it gets us to ~50KBps upload speeds.

Other than that, tons of tests are added.  The tests are pretty confusing, but look at it this way: better to have clean code and confusing tests than clean tests and confusing code.  And if you're curious about python testing with mocked IO then take a look!

Anyway, the headline is that once this is merged, smpmgr can be updated to support BLE OTA DFU for Zephyr/MCUBoot systems!