### PR TITLE
fix: the final packet may be smaller than the max allowed packet

### DIFF
--- a/smpclient/__init__.py
+++ b/smpclient/__init__.py
@@ -136,6 +136,10 @@ class SMPClient:
         h: Final = cast(smpheader.Header, request.header)
         cbor_size, data_size = self._get_max_cbor_and_data_size(request)
 
+        if data_size > len(image) - request.off:  # final packet
+            data_size = len(image) - request.off
+            cbor_size = h.length + data_size + self._cbor_integer_size(data_size)
+
         return ImageUploadWrite(
             header=smpheader.Header(
                 op=h.op,

--- a/smpclient/extensions/intercreate.py
+++ b/smpclient/extensions/intercreate.py
@@ -45,6 +45,10 @@ class ICUploadClient(SMPClient):
         h: Final = cast(smpheader.Header, request.header)
         cbor_size, data_size = self._get_max_cbor_and_data_size(request)
 
+        if data_size > len(data) - request.off:  # final packet
+            data_size = len(data) - request.off
+            cbor_size = h.length + data_size + self._cbor_integer_size(data_size)
+
         return ic.ImageUploadWrite(
             header=smpheader.Header(
                 op=h.op,


### PR DESCRIPTION
I discovered that Zephyr asserts the accuracy (good).  But it's a bug in the smp library that it gets that far!  https://github.com/JPHutchins/smp/issues/10