### PR TITLE
breaking: remove address from SMPClient; SMPTransport owns address

### DIFF
--- a/examples/ble/helloworld.py
+++ b/examples/ble/helloworld.py
@@ -16,7 +16,7 @@ async def main() -> None:
     print(f"Found {len(smp_servers)} SMP servers: {smp_servers}")
 
     print("Connecting to the first SMP server...", end="", flush=True)
-    async with SMPClient(SMPBLETransport(), smp_servers[0].address) as client:
+    async with SMPClient(SMPBLETransport(smp_servers[0].address)) as client:
         print("OK")
 
         print("Sending request...", end="", flush=True)

--- a/examples/ble/imagestate.py
+++ b/examples/ble/imagestate.py
@@ -16,7 +16,7 @@ async def main() -> None:
     print(f"Found {len(smp_servers)} SMP servers: {smp_servers}")
 
     print("Connecting to the first SMP server...", end="", flush=True)
-    async with SMPClient(SMPBLETransport(), smp_servers[0].address) as client:
+    async with SMPClient(SMPBLETransport(smp_servers[0].address)) as client:
         print("OK")
 
         print("Sending request...", end="", flush=True)

--- a/examples/ble/mcumgrparameters.py
+++ b/examples/ble/mcumgrparameters.py
@@ -16,7 +16,7 @@ async def main() -> None:
     print(f"Found {len(smp_servers)} SMP servers: {smp_servers}")
 
     print("Connecting to the first SMP server...", end="", flush=True)
-    async with SMPClient(SMPBLETransport(), smp_servers[0].address) as client:
+    async with SMPClient(SMPBLETransport(smp_servers[0].address)) as client:
         print("OK")
         print(f"Client MTU is {client._transport.mtu}B")
         print(f"Client max unencoded size is {client._transport.max_unencoded_size}B")

--- a/examples/ble/upgrade.py
+++ b/examples/ble/upgrade.py
@@ -64,7 +64,7 @@ async def main() -> None:
     print("OK")
 
     print("Connecting to A SMP DUT...", end="", flush=True)
-    async with SMPClient(SMPBLETransport(), a_smp_dut.name or a_smp_dut.address) as client:
+    async with SMPClient(SMPBLETransport(a_smp_dut.name or a_smp_dut.address)) as client:
         print("OK")
 
         async def ensure_request(request: SMPRequest[TRep, TEr1, TEr2]) -> TRep:
@@ -119,7 +119,7 @@ async def main() -> None:
     b_smp_dut = cast(BLEDevice, b_smp_dut)
 
     print("Connecting to B SMP DUT...", end="", flush=True)
-    async with SMPClient(SMPBLETransport(), b_smp_dut.name or b_smp_dut.address) as client:
+    async with SMPClient(SMPBLETransport(b_smp_dut.name or b_smp_dut.address)) as client:
         print("OK")
 
         print()

--- a/examples/ble/upload.py
+++ b/examples/ble/upload.py
@@ -30,9 +30,7 @@ async def main() -> None:
     print(f"Found {len(smp_servers)} SMP servers: {smp_servers}")
 
     print("Connecting to the first SMP server...", end="", flush=True)
-    async with SMPClient(
-        SMPBLETransport(), smp_servers[0].name or smp_servers[0].address
-    ) as client:
+    async with SMPClient(SMPBLETransport(smp_servers[0].name or smp_servers[0].address)) as client:
         print("OK")
 
         print("Sending request...", end="", flush=True)

--- a/examples/udp/helloworld.py
+++ b/examples/udp/helloworld.py
@@ -18,7 +18,7 @@ async def main() -> None:
     parser.add_argument("address", help="The IP address to connect to")
     address = parser.parse_args().address
 
-    async with SMPClient(SMPUDPTransport(), address) as client:
+    async with SMPClient(SMPUDPTransport(address)) as client:
         print("OK")
 
         print("Sending request...", end="", flush=True)

--- a/examples/usb/download_file.py
+++ b/examples/usb/download_file.py
@@ -16,7 +16,7 @@ async def main() -> None:
     port = args.port
     file_location = args.file_location
 
-    async with SMPClient(SMPSerialTransport(), port) as client:
+    async with SMPClient(SMPSerialTransport(port)) as client:
         start_s = time.time()
         file_data = await client.download_file(file_location)
         end_s = time.time()

--- a/examples/usb/helloworld.py
+++ b/examples/usb/helloworld.py
@@ -15,7 +15,7 @@ async def main() -> None:
     parser.add_argument("port", help="The serial port to connect to")
     port = parser.parse_args().port
 
-    async with SMPClient(SMPSerialTransport(), port) as client:
+    async with SMPClient(SMPSerialTransport(port)) as client:
         print("OK")
 
         print("Sending request...", end="", flush=True)

--- a/examples/usb/upgrade.py
+++ b/examples/usb/upgrade.py
@@ -108,11 +108,11 @@ async def main() -> None:
     print("Connecting to SMP DUT...", end="", flush=True)
     async with SMPClient(
         SMPSerialTransport(
+            port_a.device,
             max_smp_encoded_frame_size=max_smp_encoded_frame_size,
             line_length=line_length,
             line_buffers=line_buffers,
-        ),
-        port_a.device,
+        )
     ) as client:
         print("OK")
 
@@ -187,11 +187,11 @@ async def main() -> None:
     print("Connecting to B SMP DUT...", end="", flush=True)
     async with SMPClient(
         SMPSerialTransport(
+            port_b.device,
             max_smp_encoded_frame_size=max_smp_encoded_frame_size,
             line_length=line_length,
             line_buffers=line_buffers,
-        ),
-        port_b.device,
+        )
     ) as client:
         print("OK")
 

--- a/examples/usb/upload_file.py
+++ b/examples/usb/upload_file.py
@@ -64,7 +64,7 @@ quam, a volutpat purus. Etiam sollicitudin arcu vel elit bibendum et imperdiet r
 Etiam elit velit, posuere ut pulvinar ac, condimentum eget justo. Fusce a erat velit. Vivamus
 imperdiet ultrices orci in hendrerit.
 """
-    async with SMPClient(SMPSerialTransport(), port) as client:
+    async with SMPClient(SMPSerialTransport(port)) as client:
         start_s = time.time()
         async for offset in client.upload_file(file_data=file_data, file_path=file_path):
             print(

--- a/smpclient/__init__.py
+++ b/smpclient/__init__.py
@@ -63,7 +63,6 @@ class SMPClient:
 
     Args:
         transport: the `SMPTransport` to use
-        address: the address of the SMP server, see `smpclient.transport` for details
 
     Example:
 
@@ -74,7 +73,7 @@ class SMPClient:
     from smpclient.transport.ble import SMPBLETransport
 
     async def main():
-        async with SMPClient(SMPBLETransport(), "00:11:22:33:44:55") as client:
+        async with SMPClient(SMPBLETransport("00:11:22:33:44:55")) as client:
             response = await client.request(EchoWrite(d="Hello, World!"))
 
             if success(response):
@@ -87,9 +86,8 @@ class SMPClient:
     ```
     """
 
-    def __init__(self, transport: SMPTransport, address: str):  # noqa: DOC301
+    def __init__(self, transport: SMPTransport):  # noqa: DOC301
         self._transport: Final = transport
-        self._address: Final = address
 
     async def connect(self, timeout_s: float = 5.0) -> None:
         """Connect to the SMP server.
@@ -97,7 +95,7 @@ class SMPClient:
         Args:
             timeout_s: the timeout for the connection attempt in seconds
         """
-        await self._transport.connect(self._address, timeout_s)
+        await self._transport.connect(timeout_s)
         await self._initialize()
 
     async def disconnect(self) -> None:
@@ -386,12 +384,6 @@ class SMPClient:
 
         logger.info("Download complete")
         return file_data
-
-    @property
-    def address(self) -> str:
-        """The SMP server address."""
-
-        return self._address
 
     async def __aenter__(self) -> "SMPClient":
         await self.connect()

--- a/smpclient/transport/__init__.py
+++ b/smpclient/transport/__init__.py
@@ -13,11 +13,10 @@ class SMPTransport(Protocol):
     _smp_server_transport_buffer_size: int | None = None
     """The SMP server transport buffer size, in 8-bit bytes."""
 
-    async def connect(self, address: str, timeout_s: float) -> None:  # pragma: no cover
+    async def connect(self, timeout_s: float) -> None:  # pragma: no cover
         """Connect the `SMPTransport`.
 
         Args:
-            address: The SMP server address.
             timeout_s: The connection timeout in seconds."""
 
     async def disconnect(self) -> None:  # pragma: no cover

--- a/smpclient/transport/udp.py
+++ b/smpclient/transport/udp.py
@@ -15,21 +15,27 @@ logger = logging.getLogger(__name__)
 
 
 class SMPUDPTransport(SMPTransport):
-    def __init__(self, mtu: int = 1500) -> None:
+    def __init__(self, address: str, port: int = 1337, mtu: int = 1500) -> None:
         """Initialize the SMP UDP transport.
 
         Args:
+            address: The destination IP address.
+            port: The destination port.
             mtu: The Maximum Transmission Unit (MTU) in 8-bit bytes.
         """
-        self._mtu = mtu
+        self._address: Final = address
+        self._port: Final = port
+        self._mtu: Final = mtu
 
         self._client: Final = UDPClient()
 
     @override
-    async def connect(self, address: str, timeout_s: float, port: int = 1337) -> None:
-        logger.debug(f"Connecting to {address=} {port=}")
-        await asyncio.wait_for(self._client.connect(Addr(host=address, port=port)), timeout_s)
-        logger.info(f"Connected to {address=} {port=}")
+    async def connect(self, timeout_s: float) -> None:
+        logger.debug(f"Connecting to {self._address=} {self._port=}")
+        await asyncio.wait_for(
+            self._client.connect(Addr(host=self._address, port=self._port)), timeout_s
+        )
+        logger.info(f"Connected to {self._address=} {self._port=}")
 
     @override
     async def disconnect(self) -> None:

--- a/tests/extensions/test_intercreate.py
+++ b/tests/extensions/test_intercreate.py
@@ -24,8 +24,8 @@ async def test_upload_hello_world_bin_encoded(mock_mtu: PropertyMock) -> None:
     ) as f:
         image = f.read()
 
-    m = SMPSerialTransport()
-    s = ICUploadClient(m, "address")
+    m = SMPSerialTransport("address")
+    s = ICUploadClient(m)
     assert s._transport.mtu == 127
     assert s._transport.max_unencoded_size < 127
 

--- a/tests/test_smp_ble_transport.py
+++ b/tests/test_smp_ble_transport.py
@@ -33,7 +33,7 @@ class MockBleakClient:
 
 
 def test_constructor() -> None:
-    t = SMPBLETransport()
+    t = SMPBLETransport("my_device")
     assert t._buffer == bytearray()
     assert isinstance(t._notify_condition, asyncio.Condition)
 
@@ -91,17 +91,17 @@ async def test_connect(
     mock_find_device_by_address: MagicMock,
 ) -> None:
     # assert that it searches by name if MAC or UUID is not provided
-    await SMPBLETransport().connect("device name", 1.0)
+    await SMPBLETransport("device name").connect(1.0)
     mock_find_device_by_name.assert_called_once_with("device name")
     mock_find_device_by_name.reset_mock()
 
     # assert that it searches by MAC if MAC is provided
-    await SMPBLETransport().connect("00:00:00:00:00:00", 1.0)
+    await SMPBLETransport("00:00:00:00:00:00").connect(1.0)
     mock_find_device_by_address.assert_called_once_with("00:00:00:00:00:00", timeout=1.0)
     mock_find_device_by_address.reset_mock()
 
     # assert that it searches by UUID if UUID is provided
-    await SMPBLETransport().connect(UUID("00000000-0000-4000-8000-000000000000").hex, 1.0)
+    await SMPBLETransport(UUID("00000000-0000-4000-8000-000000000000").hex).connect(1.0)
     mock_find_device_by_address.assert_called_once_with(
         "00000000000040008000000000000000", timeout=1.0
     )
@@ -110,15 +110,15 @@ async def test_connect(
     # assert that it raises an exception if the device is not found
     mock_find_device_by_address.return_value = None
     with pytest.raises(SMPBLETransportDeviceNotFound):
-        await SMPBLETransport().connect("00:00:00:00:00:00", 1.0)
+        await SMPBLETransport("00:00:00:00:00:00").connect(1.0)
     mock_find_device_by_address.reset_mock()
 
     # assert that connect is awaited
-    t = SMPBLETransport()
-    await t.connect("name", 1.0)
+    t = SMPBLETransport("name")
+    await t.connect(1.0)
     t._client = cast(MagicMock, t._client)
     t._client.reset_mock()
-    await t.connect("name", 1.0)
+    await t.connect(1.0)
     t._client.connect.assert_awaited_once_with()
 
     # these are hard to mock now because the _client is created in the connect method
@@ -146,7 +146,7 @@ async def test_connect(
 
 @pytest.mark.asyncio
 async def test_disconnect() -> None:
-    t = SMPBLETransport()
+    t = SMPBLETransport("name_or_address")
     t._client = MagicMock(spec=BleakClient)
     await t.disconnect()
     t._client.disconnect.assert_awaited_once_with()
@@ -154,7 +154,7 @@ async def test_disconnect() -> None:
 
 @pytest.mark.asyncio
 async def test_send() -> None:
-    t = SMPBLETransport()
+    t = SMPBLETransport("name_or_address")
     t._client = MagicMock(spec=BleakClient)
     t._smp_characteristic = MagicMock(spec=BleakGATTCharacteristic)
     t._smp_characteristic.max_write_without_response_size = 20
@@ -166,7 +166,7 @@ async def test_send() -> None:
 
 @pytest.mark.asyncio
 async def test_receive() -> None:
-    t = SMPBLETransport()
+    t = SMPBLETransport("name_or_address")
     t._client = MagicMock(spec=BleakClient)
     t._smp_characteristic = MagicMock(spec=BleakGATTCharacteristic)
     t._smp_characteristic.uuid = str(SMP_CHARACTERISTIC_UUID)
@@ -197,7 +197,7 @@ async def test_receive() -> None:
 
 @pytest.mark.asyncio
 async def test_send_and_receive() -> None:
-    t = SMPBLETransport()
+    t = SMPBLETransport("name_or_address")
     t.send = AsyncMock()  # type: ignore
     t.receive = AsyncMock()  # type: ignore
     await t.send_and_receive(b"Hello pytest!")
@@ -206,14 +206,14 @@ async def test_send_and_receive() -> None:
 
 
 def test_max_unencoded_size() -> None:
-    t = SMPBLETransport()
+    t = SMPBLETransport("name_or_address")
     t._client = MagicMock(spec=BleakClient)
     t._max_write_without_response_size = 42
     assert t.max_unencoded_size == 42
 
 
 def test_max_unencoded_size_mcumgr_param() -> None:
-    t = SMPBLETransport()
+    t = SMPBLETransport("name_or_address")
     t._client = MagicMock(spec=BleakClient)
     t._smp_server_transport_buffer_size = 9001
     assert t.max_unencoded_size == 9001

--- a/tests/test_smp_client.py
+++ b/tests/test_smp_client.py
@@ -80,26 +80,25 @@ class SMPMockTransport:
 
 def test_constructor() -> None:
     m = SMPMockTransport()
-    s = SMPClient(m, "address")
+    s = SMPClient(m)
     assert s._transport is m
-    assert s._address == "address"
 
 
 @pytest.mark.asyncio
 async def test_connect() -> None:
     m = SMPMockTransport()
-    s = SMPClient(m, "address")
+    s = SMPClient(m)
     s._initialize = AsyncMock()  # type: ignore
     await s.connect()
 
-    m.connect.assert_awaited_once_with("address", 5.0)
+    m.connect.assert_awaited_once_with(5.0)
     s._initialize.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
 async def test_request() -> None:
     m = SMPMockTransport()
-    s = SMPClient(m, "address")
+    s = SMPClient(m)
 
     req = ResetWrite()
     m.receive.return_value = ResetWriteResponse(sequence=req.header.sequence).BYTES
@@ -178,7 +177,7 @@ async def test_request() -> None:
 @pytest.mark.asyncio
 async def test_upload() -> None:
     m = SMPMockTransport()
-    s = SMPClient(m, "address")
+    s = SMPClient(m)
 
     s.request = AsyncMock()  # type: ignore
 
@@ -299,7 +298,7 @@ async def test_upload_hello_world_bin(
         image = f.read()
 
     m = SMPMockTransport()
-    s = SMPClient(m, "address")
+    s = SMPClient(m)
 
     accumulated_image = bytearray([])
 
@@ -334,11 +333,12 @@ async def test_upload_hello_world_bin_encoded(
         pytest.skip("The line buffer size is too small")
 
     m = SMPSerialTransport(
+        "address",
         max_smp_encoded_frame_size=max_smp_encoded_frame_size,
         line_length=line_length,
         line_buffers=line_buffers,
     )
-    s = SMPClient(m, "address")
+    s = SMPClient(m)
     assert s._transport.mtu == max_smp_encoded_frame_size
 
     packets: List[bytes] = []
@@ -389,7 +389,7 @@ async def test_upload_hello_world_bin_encoded(
 @pytest.mark.asyncio
 async def test_upload_file() -> None:
     m = SMPMockTransport()
-    s = SMPClient(m, "address")
+    s = SMPClient(m)
 
     s.request = AsyncMock()  # type: ignore
 
@@ -502,7 +502,7 @@ async def test_file_upload_test_txt(
         data = f.read()
 
     m = SMPMockTransport()
-    s = SMPClient(m, "address")
+    s = SMPClient(m)
 
     accumulated_data = bytearray([])
 
@@ -533,11 +533,12 @@ async def test_file_upload_test_encoded(max_smp_encoded_frame_size: int, line_bu
         pytest.skip("The line buffer size is too small")
 
     m = SMPSerialTransport(
+        "address",
         max_smp_encoded_frame_size=max_smp_encoded_frame_size,
         line_length=line_length,
         line_buffers=line_buffers,
     )
-    s = SMPClient(m, "address")
+    s = SMPClient(m)
     assert s._transport.mtu == max_smp_encoded_frame_size
 
     packets: List[bytes] = []
@@ -588,7 +589,7 @@ async def test_file_upload_test_encoded(max_smp_encoded_frame_size: int, line_bu
 @pytest.mark.asyncio
 async def test_download_file() -> None:
     m = SMPMockTransport()
-    s = SMPClient(m, "address")
+    s = SMPClient(m)
 
     s.request = AsyncMock()  # type: ignore
 
@@ -770,7 +771,7 @@ async def test_download_file() -> None:
 @pytest.mark.asyncio
 async def test_download_file_error_first() -> None:
     m = SMPMockTransport()
-    s = SMPClient(m, "address")
+    s = SMPClient(m)
 
     s.request = AsyncMock()  # type: ignore
 
@@ -803,7 +804,7 @@ async def test_download_file_error_first() -> None:
 @pytest.mark.asyncio
 async def test_download_file_no_len_first() -> None:
     m = SMPMockTransport()
-    s = SMPClient(m, "address")
+    s = SMPClient(m)
 
     s.request = AsyncMock()  # type: ignore
 
@@ -836,7 +837,7 @@ async def test_download_file_no_len_first() -> None:
 @pytest.mark.asyncio
 async def test_download_file_error_not_first() -> None:
     m = SMPMockTransport()
-    s = SMPClient(m, "address")
+    s = SMPClient(m)
 
     s.request = AsyncMock()  # type: ignore
 


### PR DESCRIPTION
I've long thought that passing the SMP server "address" to the SMPClient class instead of the SMPTransport implementation classes was a mistake. "address" means different things to the different transports. Notably, this change allows the UDP transport to clearly take an address and a port argument, rather than just an address.

Unfortunately this is a breaking change. While all existing address args should still be valid, they must be moved from "1st arg of SMPClient() to 1st arg of SMPTransport".

@M1cha this is what I have in mind as the breaking change required to continue implementing the unique requirements of each transport for smpmgr.