### PR TITLE
Bugfix incorrect header lenght, with packet of data size 0xFF or 0xFFFF 

### DIFF
--- a/smpclient/__init__.py
+++ b/smpclient/__init__.py
@@ -414,7 +414,7 @@ class SMPClient:
         # If the integer is less than 24, then the size is encoded in the same
         # byte as the value.
         # https://datatracker.ietf.org/doc/html/rfc8949#name-core-deterministic-encoding
-        return 0 if integer < 24 else 1 if integer < 0xFF else 2 if integer < 0xFFFF else 4
+        return 0 if integer < 24 else 1 if integer <= 0xFF else 2 if integer <= 0xFFFF else 4
 
     def _get_max_cbor_and_data_size(self, request: smpmsg.WriteRequest) -> Tuple[int, int]:
         """Given an `ImageUploadWrite`, return the maximum CBOR size and data size."""

--- a/tests/fixtures/file_system/255_bytes.txt
+++ b/tests/fixtures/file_system/255_bytes.txt
@@ -1,0 +1,3 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla est purus, ultrices in porttitor
+in, accumsan non quam. Nam consectetur porttitor rhoncus. Curabitur eu est et leo feugiat
+auctor vel quis lorem. Ut et ligula dolor, sit amet consequat lorem.


### PR DESCRIPTION
Fixed a bug causing the header length to be incorrect when the last packet had a size of 0xFF or 0xFFFF. The cbor_integer_size function returned 1 bytes to much for the value of 0xFF and 0xFFFF. 