### PR TITLE
fix: SMPClient context logs formatted traceback, not repr

### DIFF
--- a/smpclient/__init__.py
+++ b/smpclient/__init__.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import traceback
 from hashlib import sha256
 from types import TracebackType
 from typing import AsyncIterator, Final, Tuple, Type
@@ -401,10 +402,10 @@ class SMPClient:
         self,
         exc_type: Type[BaseException] | None,
         exc_value: BaseException | None,
-        traceback: TracebackType | None,
+        tb: TracebackType | None,
     ) -> None:
         if exc_value is not None:
-            logger.error(f"Exception in SMPClient: {exc_type=}, {exc_value=}, {traceback=}")
+            logger.error(f"Exception in SMPClient:\n{traceback.format_exc()}")
         await self.disconnect()
 
     @staticmethod


### PR DESCRIPTION
Previously, exiting the SMPClient async context with an exception results in logging f"{traceback=}" whose output looks like:

> `traceback=<traceback object at 0x7f4c3fea2980>`

as part of a full log message like so:

> `Exception in SMPClient: exc_type=<class 'smpclient.transport.SMPTransportDisconnected'>, exc_value=SMPTransportDisconnected('SmpNativeTransport cancelled receive due to disconnection'), traceback=<traceback object at 0x7f4c3fea2980>`

Instead, format the exception using traceback.format_exc() (which also grabs the originating exception with sys.exception()). Now the output looks like:

> ```
>   Exception in SMPClient:
>   Traceback (most recent call last):
>     File "<string>", line 11, in run_echo_test
>     File "/opt/axe/develop/latest/desktop/sysroots/x86-64-v3-poky-linux/usr/lib/python3.12/site-packages/smpclient/__init__.py", line 160, in request
>       frame = await self._transport.send_and_receive(request.BYTES)
>               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>     File "<string>", line 67, in send_and_receive
>     File "<string>", line 62, in receive
>   smpclient.transport.SMPTransportDisconnected: SmpNativeTransport cancelled receive due to disconnection
> ```