### PR TITLE
smpclient: mcuboot: treat all files as binary except for .hex

### DIFF
--- a/smpclient/mcuboot.py
+++ b/smpclient/mcuboot.py
@@ -230,7 +230,12 @@ class ImageInfo:
 
     @staticmethod
     def load_file(path: str) -> 'ImageInfo':
-        """Load MCUBoot `ImageInfo` from the .bin or .hex file at `path`."""
+        """
+        Load MCUBoot `ImageInfo` from the file at `path`.
+
+        Files with the `.hex` extension are treated as Intel HEX format.
+        All other file extensions are treated as binary.
+        """
         file_path = pathlib.Path(path)
 
         if file_path.suffix != ".hex":


### PR DESCRIPTION
Remove limitations on file extensions and treat all of them as binary except for .hex.

This type of self-imposed limitation IMHO belongs in end-user tools where it might have some sort of use (e.g. platform-specific binaries generated by other tools), but not in a generic library like this.