### PR TITLE
Cleanup serial data handling

### DIFF
--- a/smpclient/transport/serial.py
+++ b/smpclient/transport/serial.py
@@ -42,30 +42,17 @@ class SMPSerialTransport(SMPTransport):
     _POLLING_INTERVAL_S = 0.005
     _CONNECTION_RETRY_INTERVAL_S = 0.500
 
-    class _ReadBuffer:
-        """The state of the read buffer."""
+    @unique
+    class BufferState(IntEnum):
+        SMP = 0
+        """An SMP start or continue delimiter has been received and
+        `_buffer` is being parsed as an SMP packet.
+        """
 
-        @unique
-        class State(IntEnum):
-            SMP = 0
-            """An SMP start or continue delimiter has been received and the
-            `smp_buffer` is being filled with the remainder of the SMP packet.
-            """
-
-            SER = 1
-            """The SMP start delimiter has not been received and the
-            `ser_buffer` is being filled with data.
-            """
-
-        def __init__(self) -> None:
-            self.smp = bytearray([])
-            """The buffer for the SMP packet."""
-
-            self.ser = bytearray([])
-            """The buffer for serial data that is not part of an SMP packet."""
-
-            self.state = SMPSerialTransport._ReadBuffer.State.SER
-            """The state of the read buffer."""
+        SERIAL = 1
+        """The SMP start delimiter has not been received and
+        `_buffer` is being parsed as serial data.
+        """
 
     def __init__(  # noqa: DOC301
         self,
@@ -131,17 +118,36 @@ class SMPSerialTransport(SMPTransport):
             inter_byte_timeout=inter_byte_timeout,
             exclusive=exclusive,
         )
-        self._buffer = SMPSerialTransport._ReadBuffer()
+
+        self._smp_packet_queue: asyncio.Queue[bytes] = asyncio.Queue()
+        """Contains full SMP packets."""
+        self._serial_buffer = bytearray()
+        """Contains any non-SMP serial data."""
+        self._buffer: bytearray = bytearray([])
+        """Contains all incoming data (serial + SMP intertwined, may be incomplete)."""
+        self._buffer_state = SMPSerialTransport.BufferState.SERIAL
+        """The state of the read buffer."""
+
         logger.debug(f"Initialized {self.__class__.__name__}")
+
+    def _reset_state(self) -> None:
+        """Reset internal state and queues for a fresh connection."""
+
+        self._smp_packet_queue = asyncio.Queue()
+        self._serial_buffer.clear()
+        self._buffer = bytearray([])
+        self._buffer_state = SMPSerialTransport.BufferState.SERIAL
 
     @override
     async def connect(self, address: str, timeout_s: float) -> None:
+        self._reset_state()
         self._conn.port = address
         logger.debug(f"Connecting to {self._conn.port=}")
         start_time: Final = time.time()
         while time.time() - start_time <= timeout_s:
             try:
                 self._conn.open()
+                self._conn.reset_input_buffer()
                 logger.debug(f"Connected to {self._conn.port=}")
                 return
             except SerialException as e:
@@ -189,112 +195,145 @@ class SMPSerialTransport(SMPTransport):
 
         logger.debug("Waiting for response")
         while True:
+            b = await self._read_one_smp_packet()
             try:
-                b = await self._readuntil()
                 decoder.send(b)
             except StopIteration as e:
                 logger.debug(f"Finished receiving {len(e.value)} byte response")
                 return e.value
-            except SerialException as e:
-                logger.error(f"Failed to receive response: {e}")
-                raise SMPTransportDisconnected(
-                    f"{self.__class__.__name__} disconnected from {self._conn.port}"
-                )
 
-    async def _readuntil(self) -> bytes:
-        """Read `bytes` until the `delimiter` then return the `bytes` including the `delimiter`."""
+    async def _read_one_smp_packet(self) -> bytes:
+        """Returns one received SMP packet from the queue.
+        Raises `SMPTransportDisconnected` if disconnected"""
+        if not self._smp_packet_queue.empty():
+            # There may already be a response in the queue, if for some reason we've received
+            # multiple responses and haven't read them in-between. This is not standard but
+            # it is possible, and easier to implement this way.
+            return self._smp_packet_queue.get_nowait()
 
-        START_DELIMITER: Final = smppacket.SIXTY_NINE
-        CONTINUE_DELIMITER: Final = smppacket.FOUR_TWENTY
-        END_DELIMITER: Final = b"\n"
+        await self._read_and_process(read_until_one_smp_packet=True)
+        return self._smp_packet_queue.get_nowait()
 
-        # fake async until I get around to replacing pyserial
+    async def read_serial(self, delimiter: bytes | None = None) -> bytes:
+        """Drain regular serial traffic (non-SMP bytes) until given delimiter.
+        Returns all available bytes if no delimiter is given.
+        May return empty bytes if nothing has been received."""
+        await self._read_and_process(read_until_one_smp_packet=False)
+        if delimiter is None:
+            res = bytes(self._serial_buffer)
+            self._serial_buffer.clear()
+            return res
+        else:
+            try:
+                first_match, remaining_data = self._serial_buffer.split(delimiter, 1)
+            except ValueError:
+                return bytes()
+            self._serial_buffer = remaining_data
+            return bytes(first_match)
 
-        i_smp_start = 0
-        i_smp_end = 0
-        i_start: int | None = None
-        i_continue: int | None = None
+    async def _read_and_process(self, read_until_one_smp_packet: bool) -> None:
+        """Reads raw data from serial and processes it into SMP packets and regular serial data."""
         while True:
-            if self._buffer.state == SMPSerialTransport._ReadBuffer.State.SER:
-                # read the entire OS buffer
-                try:
-                    self._buffer.ser.extend(self._conn.read_all() or [])
-                except StopIteration:
-                    pass
+            try:
+                data = self._conn.read_all() or b""
+            except StopIteration:
+                data = b""
+            except SerialException as exc:
+                raise SMPTransportDisconnected(f"Failed to read from {self._conn.port}: {exc}")
 
-                try:  # search the buffer for the index of the start delimiter
-                    i_start = self._buffer.ser.index(START_DELIMITER)
-                except ValueError:
-                    i_start = None
+            if data:
+                self._buffer.extend(data)
+                await self._process_buffer()
+            else:
+                await asyncio.sleep(SMPSerialTransport._POLLING_INTERVAL_S)
 
-                try:  # search the buffer for the index of the continue delimiter
-                    i_continue = self._buffer.ser.index(CONTINUE_DELIMITER)
-                except ValueError:
-                    i_continue = None
+            if read_until_one_smp_packet:
+                if self._smp_packet_queue.qsize():
+                    break  # Packet found; exit early
+            else:
+                # Just polling serial data
+                break
 
-                if i_start is not None and i_continue is not None:
-                    i_smp_start = min(i_start, i_continue)
-                elif i_start is not None:
-                    i_smp_start = i_start
-                elif i_continue is not None:
-                    i_smp_start = i_continue
-                else:  # no delimiters found yet, clear non SMP data and wait
-                    while True:
-                        try:  # search the buffer for newline characters
-                            i = self._buffer.ser.index(b"\n")
-                            try:  # log as a string if possible
-                                logger.warning(
-                                    f"{self._conn.port}: {self._buffer.ser[:i].decode()}"
-                                )
-                            except UnicodeDecodeError:  # log as bytes if not
-                                logger.warning(f"{self._conn.port}: {self._buffer.ser[:i].hex()}")
-                            self._buffer.ser = self._buffer.ser[i + 1 :]
-                        except ValueError:
-                            break
-                    await asyncio.sleep(SMPSerialTransport._POLLING_INTERVAL_S)
-                    continue
+    async def _process_buffer(self) -> None:
+        """Process buffered data until more bytes are needed."""
 
-                if i_smp_start != 0:  # log the rest of the serial buffer
-                    try:  # log as a string if possible
-                        logger.warning(
-                            f"{self._conn.port}: {self._buffer.ser[:i_smp_start].decode()}"
-                        )
-                    except UnicodeDecodeError:  # log as bytes if not
-                        logger.warning(f"{self._conn.port}: {self._buffer.ser[:i_smp_start].hex()}")
+        while True:
+            if self._buffer_state == SMPSerialTransport.BufferState.SERIAL:
+                should_continue = await self._process_buffer_as_serial_data()
+            else:
+                should_continue = await self._process_buffer_as_smp_data()
 
-                self._buffer.smp = self._buffer.ser[i_smp_start:]
-                self._buffer.ser.clear()
-                self._buffer.state = SMPSerialTransport._ReadBuffer.State.SMP
-                i_smp_end = 0
+            if not should_continue:
+                break
 
-                # don't await since the buffer may already contain the end delimiter
+    async def _process_buffer_as_serial_data(self) -> bool:
+        """Handle non-SMP data and transition to SMP state when finding SMP frame-start delimiters.
+        Return True if further data remains to process in the buffer; return False otherwise."""
 
-            elif self._buffer.state == SMPSerialTransport._ReadBuffer.State.SMP:
-                # read the entire OS buffer
-                try:
-                    self._buffer.smp.extend(self._conn.read_all() or [])
-                except StopIteration:
-                    pass
+        if not self._buffer:
+            return False
 
-                try:  # search the buffer for the index of the delimiter
-                    i_smp_end = self._buffer.smp.index(END_DELIMITER, i_smp_end) + len(
-                        END_DELIMITER
-                    )
-                except ValueError:  # delimiter not found yet, wait
-                    await asyncio.sleep(SMPSerialTransport._POLLING_INTERVAL_S)
-                    continue
+        smp_packet_start: int = self._find_smp_packet_start(self._buffer)
+        if smp_packet_start >= 0:
+            serial_data, remaining_data = (
+                self._buffer[:smp_packet_start],
+                self._buffer[smp_packet_start:],
+            )
+            self._serial_buffer.extend(serial_data)
 
-                # out is everything up to and including the delimiter
-                out = self._buffer.smp[:i_smp_end]
-                logger.debug(f"Received {len(out)} byte chunk")
+            self._buffer = remaining_data
+            self._buffer_state = SMPSerialTransport.BufferState.SMP
+            return True
 
-                # there may be some leftover to save for the next read, but
-                # it's not necessarily SMP data
-                self._buffer.ser = self._buffer.smp[i_smp_end:]
+        # No complete delimiter found - everything is serial data, with one rare edge
+        # case: last byte of buffer could be an incomplete delimiter - must preserve it for now.
+        if self._could_be_smp_packet_start(self._buffer[-1]):
+            self._serial_buffer.extend(self._buffer[:-1])
+            self._buffer = self._buffer[-1:]
+        else:
+            self._serial_buffer.extend(self._buffer)
+            self._buffer.clear()
+        return False
 
-                self._buffer.state = SMPSerialTransport._ReadBuffer.State.SER
+    async def _process_buffer_as_smp_data(self) -> bool:
+        """Handle SMP data and transition to SERIAL state when finding SMP frame-end delimiter.
+        Return True if further data remains to process in the buffer; return False otherwise."""
 
-                return out
+        smp_packet_end: int = self._buffer.find(smppacket.END_DELIMITER)
+        if smp_packet_end == -1:
+            return False
+        smp_packet_end += len(smppacket.END_DELIMITER)
+
+        smp_data, remaining_data = (
+            self._buffer[:smp_packet_end],
+            self._buffer[smp_packet_end:],
+        )
+        await self._smp_packet_queue.put(bytes(smp_data))
+
+        self._buffer = remaining_data
+        # Even if the remaining data is actually SMP data, then the next serial parse
+        # will simply put us right back into SMP state - no need to check here.
+        self._buffer_state = SMPSerialTransport.BufferState.SERIAL
+
+        return bool(self._buffer)
+
+    def _find_smp_packet_start(self, buf: bytearray) -> int:
+        """Return index of the earliest SMP frame-start delimiter, if any; -1 if none found."""
+
+        indices = [
+            i
+            for i in (
+                buf.find(smppacket.START_DELIMITER),
+                buf.find(smppacket.CONTINUE_DELIMITER),
+            )
+            if i != -1
+        ]
+        return min(indices) if indices else -1
+
+    def _could_be_smp_packet_start(self, byte: int) -> bool:
+        """Return True if the given byte value matches the start of any SMP packet delimiter."""
+
+        return byte == smppacket.START_DELIMITER[0] or byte == smppacket.CONTINUE_DELIMITER[0]
 
     @override
     async def send_and_receive(self, data: bytes) -> bytes:

--- a/tests/test_smp_serial_transport.py
+++ b/tests/test_smp_serial_transport.py
@@ -1,52 +1,49 @@
 """Tests for `SMPSerialTransport`."""
 
-import logging
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Generator
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
-from serial import Serial
+from serial import SerialException
 from smp import packet as smppacket
 
 from smpclient.requests.os_management import EchoWrite
+from smpclient.transport import SMPTransportDisconnected
 from smpclient.transport.serial import SMPSerialTransport
 
 
-def test_constructor() -> None:
-    t = SMPSerialTransport()
-    assert isinstance(t._conn, Serial)
+@pytest.fixture(autouse=True)
+def mock_serial() -> Generator[None, Any, None]:
+    with patch("smpclient.transport.serial.Serial"):
+        yield
 
+
+def test_constructor() -> None:
     t = SMPSerialTransport(max_smp_encoded_frame_size=512, line_length=128, line_buffers=4)
-    assert isinstance(t._conn, Serial)
     assert t.mtu == 512
     assert t.max_unencoded_size < 512
 
 
-@patch("smpclient.transport.serial.Serial")
 @pytest.mark.asyncio
-async def test_connect(_: MagicMock) -> None:
-    t = SMPSerialTransport()
-
-    await t.connect("COM2", 1.0)
-    assert t._conn.port == "COM2"
-
-    t._conn.open.assert_called_once()  # type: ignore
-
-    t._conn.reset_mock()  # type: ignore
+async def test_connect_disconnect() -> None:
+    ports: list[str] = ["COM2", "/dev/ttyACM0", "/dev/ttyUSB0"]
 
     t = SMPSerialTransport()
+    t._conn.read_all = MagicMock(return_value=b"")  # type: ignore
 
-    await t.connect("/dev/ttyACM0", 1.0)
-    assert t._conn.port == "/dev/ttyACM0"
+    for p in ports:
+        await asyncio.wait_for(t.connect(p, 1.0), timeout=1.0)
+        t._conn.open.assert_called_once()  # type: ignore
 
-    t._conn.open.assert_called_once()  # type: ignore
+        assert t._conn.port == p
 
+        await asyncio.wait_for(t.disconnect(), timeout=0.1)
+        t._conn.close.assert_called_once()  # type: ignore
 
-@patch("smpclient.transport.serial.Serial")
-@pytest.mark.asyncio
-async def test_disconnect(_: MagicMock) -> None:
-    t = SMPSerialTransport()
-    await t.disconnect()
-    t._conn.close.assert_called_once()  # type: ignore
+        t._conn.reset_mock()  # type: ignore
 
 
 @pytest.mark.asyncio
@@ -75,23 +72,26 @@ async def test_receive() -> None:
     t = SMPSerialTransport()
     m = EchoWrite._Response.get_default()(sequence=0, r="Hello pytest!")  # type: ignore
     p = [p for p in smppacket.encode(m.BYTES, t.max_unencoded_size)]
-    t._readuntil = AsyncMock(side_effect=p)  # type: ignore
+    t._read_one_smp_packet = AsyncMock(side_effect=p)  # type: ignore
 
     b = await t.receive()
-    t._readuntil.assert_awaited_once_with()
+    t._read_one_smp_packet.assert_awaited_once_with()
+
     assert b == m.BYTES
 
     p = [p for p in smppacket.encode(m.BYTES, 8)]  # test packet fragmentation
-    t._readuntil = AsyncMock(side_effect=p)  # type: ignore
+    t._read_one_smp_packet = AsyncMock(side_effect=p)  # type: ignore
 
     b = await t.receive()
-    t._readuntil.assert_awaited()
+    t._read_one_smp_packet.assert_awaited()
     assert b == m.BYTES
 
 
 @pytest.mark.asyncio
-async def test_readuntil() -> None:
+async def test_read_one_smp_packet() -> None:
     t = SMPSerialTransport()
+    await t.connect("COM2", timeout_s=1.0)
+
     m1 = EchoWrite._Response.get_default()(sequence=0, r="Hello pytest!")  # type: ignore
     m2 = EchoWrite._Response.get_default()(sequence=1, r="Hello computer!")  # type: ignore
     p1 = [p for p in smppacket.encode(m1.BYTES, 8)]
@@ -100,7 +100,7 @@ async def test_readuntil() -> None:
     t._conn.read_all = MagicMock(side_effect=packets)  # type: ignore
 
     for p in packets:
-        assert p == await t._readuntil()
+        assert p == await t._read_one_smp_packet()
 
     # do again, but manually fragment the buffers
     packets = [p for p in smppacket.encode(m1.BYTES, 512)] + [
@@ -120,46 +120,9 @@ async def test_readuntil() -> None:
     t._conn.read_all = MagicMock(side_effect=buffers)  # type: ignore
 
     for p in packets:
-        assert p == await t._readuntil()
+        assert p == await t._read_one_smp_packet()
 
-
-@pytest.mark.asyncio
-async def test_readuntil_with_smp_server_logging(caplog: pytest.LogCaptureFixture) -> None:
-    t = SMPSerialTransport()
-    m1 = EchoWrite._Response.get_default()(sequence=0, r="Hello pytest!")  # type: ignore
-    m2 = EchoWrite._Response.get_default()(sequence=1, r="Hello computer!")  # type: ignore
-    p1 = [p for p in smppacket.encode(m1.BYTES, 8)]
-    p2 = [p for p in smppacket.encode(m2.BYTES, 8)]
-    packets = p1 + p2
-
-    t._conn.read_all = MagicMock(  # type: ignore
-        side_effect=(
-            [b"Hi, there!"]
-            + [b"newline \n"]
-            + [b"Another line\nAgain \n"]
-            + [b"log with no newline"]
-            + p1
-            + [b"Thought \n I'd just say hi!\n"]
-            + [bytes([0, 1, 2, 3])]
-            + [b"Bye!\n"]
-            + p2
-            + [b"One more thing...\n"]
-            + [b"We \n could \n use \n newlines\n"]
-        )
-    )
-
-    t._conn.port = "/dev/ttyUSB0"
-
-    with caplog.at_level(logging.WARNING):
-        for p in packets:
-            assert p == await t._readuntil()
-
-        messages = {r.message for r in caplog.records}
-        assert "/dev/ttyUSB0: Hi, there!newline " in messages
-        assert "/dev/ttyUSB0: Another line" in messages
-        assert "/dev/ttyUSB0: Again " in messages
-        assert "/dev/ttyUSB0: log with no newline" in messages
-        assert "/dev/ttyUSB0: Thought \n I'd just say hi!\n\x00\x01\x02\x03Bye!\n" in messages
+    await t.disconnect()
 
 
 @pytest.mark.asyncio
@@ -172,3 +135,127 @@ async def test_send_and_receive() -> None:
 
     t.send.assert_awaited_once_with(b"some data")
     t.receive.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_receive_timeout() -> None:
+    t = SMPSerialTransport(timeout=0.1)
+    t._read_one_smp_packet = AsyncMock(side_effect=TimeoutError)  # type: ignore
+
+    with pytest.raises(TimeoutError):
+        await t.receive()
+
+
+@pytest.mark.asyncio
+async def test_only_serial_data_no_smp() -> None:
+    t = SMPSerialTransport()
+    await t.connect("/dev/ttyACM0", timeout_s=1.0)
+
+    t._conn.read_all = MagicMock(  # type: ignore
+        side_effect=[
+            b"First line\n",
+            b"Second line\nThird line\n",
+            b"Partial line",
+            b" continues here\n",
+            b"No newline at end",
+        ]
+    )
+
+    data = await t.read_serial(delimiter=b"\n")
+    assert data == b"First line"
+
+    data = await t.read_serial(delimiter=b"\n")
+    assert data == b"Second line"
+
+    data = await t.read_serial(delimiter=b"\n")
+    assert data == b"Third line"
+
+    data = await t.read_serial(delimiter=b"\n")
+    assert data == b"Partial line continues here"
+
+    # Last line is not newline terminated:
+    data = await t.read_serial(delimiter=b"\n")
+    assert data == b""
+    # So read remaining data without delimiter
+    data = await t.read_serial()
+    assert data == b"No newline at end"
+
+    await t.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_only_smp_data_no_serial() -> None:
+    t = SMPSerialTransport()
+    await t.connect("/dev/ttyUSB0", timeout_s=1.0)
+
+    m1 = EchoWrite._Response.get_default()(sequence=0, r="SMP Message 1")  # type: ignore
+    m2 = EchoWrite._Response.get_default()(sequence=1, r="SMP Message 2")  # type: ignore
+    m3 = EchoWrite._Response.get_default()(sequence=2, r="SMP Message 3")  # type: ignore
+
+    packets = (
+        list(smppacket.encode(m1.BYTES, 512))
+        + list(smppacket.encode(m2.BYTES, 512))
+        + list(smppacket.encode(m3.BYTES, 512))
+    )
+
+    t._conn.read_all = MagicMock(side_effect=packets)  # type: ignore
+
+    for expected_msg in [m1.BYTES, m2.BYTES, m3.BYTES]:
+        received = await t.receive()
+        assert received == expected_msg
+
+    await t.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_serial_and_smp_data() -> None:
+    t = SMPSerialTransport()
+    await t.connect("/dev/ttyUSB0", timeout_s=1.0)
+
+    m1 = EchoWrite._Response.get_default()(sequence=0, r="SMP1")  # type: ignore
+    m2 = EchoWrite._Response.get_default()(sequence=1, r="SMP2")  # type: ignore
+
+    p1 = next(smppacket.encode(m1.BYTES, 512))
+    p2 = next(smppacket.encode(m2.BYTES, 512))
+
+    t._conn.read_all = MagicMock(  # type: ignore
+        side_effect=[
+            b"Start\n" + p1[:10],
+            p1[10:] + b"Mid1\n",
+            b"Mid2\n" + p2,
+            b"End\n",
+        ]
+    )
+
+    # Note that SMP and serial data may be read in any order, so reading SMP packets
+    # first in a row must work:
+
+    received1 = await t.receive()
+    assert received1 == m1.BYTES
+
+    received2 = await t.receive()
+    assert received2 == m2.BYTES
+
+    data = await t.read_serial(delimiter=b"\n")
+    assert data == b"Start"
+
+    data = await t.read_serial(delimiter=b"\n")
+    assert data == b"Mid1"
+
+    data = await t.read_serial(delimiter=b"\n")
+    assert data == b"Mid2"
+
+    data = await t.read_serial(delimiter=b"\n")
+    assert data == b"End"
+
+    await t.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_not_connected_exception_handling() -> None:
+    t = SMPSerialTransport()
+    t._conn.is_open = False
+    t._conn.read_all = MagicMock(side_effect=SerialException("Not connected"))  # type: ignore
+
+    with pytest.raises(SMPTransportDisconnected):
+        await t.receive()


### PR DESCRIPTION
chore: Cleanup non-smp serial data handling.

Makes the buffer processing hopefully a bit more clear. Non-SMP data is no longer logged to stdout but can be accessed with the read_serial() function.