### PR TITLE
BREAKING: ble and serial dependencies are optional

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,6 +35,56 @@ jobs:
             dist/*.tar.gz
             dist/*.whl
 
+  transport-extras:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: no-extras
+            extras: ""
+            expect-serial: fail
+            expect-ble: fail
+          - name: serial-only
+            extras: "[serial]"
+            expect-serial: pass
+            expect-ble: fail
+          - name: ble-only
+            extras: "[ble]"
+            expect-serial: fail
+            expect-ble: pass
+          - name: all
+            extras: "[all]"
+            expect-serial: pass
+            expect-ble: pass
+    name: transport-extras (${{ matrix.name }})
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v6
+
+      - run: uv venv && uv pip install .${{ matrix.extras }}
+
+      - name: serial transport should ${{ matrix.expect-serial }}
+        run: |
+          if [ "${{ matrix.expect-serial }}" = "pass" ]; then
+            .venv/bin/python -c "from smpclient.transport.serial import SMPSerialTransport"
+          else
+            ! .venv/bin/python -c "from smpclient.transport.serial import SMPSerialTransport" 2>/dev/null
+          fi
+
+      - name: ble transport should ${{ matrix.expect-ble }}
+        run: |
+          if [ "${{ matrix.expect-ble }}" = "pass" ]; then
+            .venv/bin/python -c "from smpclient.transport.ble import SMPBLETransport"
+          else
+            ! .venv/bin/python -c "from smpclient.transport.ble import SMPBLETransport" 2>/dev/null
+          fi
+
+      - name: udp transport should pass
+        run: .venv/bin/python -c "from smpclient.transport.udp import SMPUDPTransport"
+
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,28 @@ If you'd like an SMP CLI application instead of a library, then you should try
 
 `smpclient` is [distributed by PyPI](https://pypi.org/project/smpclient/) and can be installed with `uv`, `pip`, and other dependency managers.
 
+Build with all transports:
+
+```
+smpclient[all]
+```
+
+Or none (UDP transport only):
+
+```
+smpclient
+```
+
+Or build with only the transports you need:
+
+```
+smpclient[serial] # Serial (UART, USB, CAN)
+smpclient[ble] # Bluetooth Low Energy
+smpclient[serial,ble] # Serial + BLE
+```
+
+The UDP transport has no additional dependencies and is always available.
+
 ## User Documentation
 
 Documentation is in the source code so that it is available to your editor.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,16 @@ classifiers = [
 "Operating System :: MacOS :: MacOS X",
 ]
 dependencies = [
-"pyserial>=3.5",
 "smp>=4.0.2",
 "intelhex>=2.3.0",
-"bleak>=2.0.0",
 "async-timeout>=4.0.3; python_version < '3.11'",
 ]
+
+[project.optional-dependencies]
+serial = ["pyserial>=3.5"]
+ble = ["bleak>=2.0.0"]
+udp = []
+all = ["smpclient[serial,ble,udp]"]
 
 [project.urls]
 Homepage = "https://www.intercreate.io"
@@ -46,6 +50,7 @@ source = "vcs"
 
 [dependency-groups]
 dev = [
+"smpclient[all]",
 "hatch>=1.14.1",
 "mypy>=1.7.0",
 "mypy-extensions>=1.0.0",

--- a/src/smpclient/__init__.py
+++ b/src/smpclient/__init__.py
@@ -7,6 +7,18 @@ updates, file management, configuration, and statistics retrieval.
 Additionally, SMP is extensible, allowing for custom commands to be defined to
 meet the specific needs of the product.
 
+### Transports
+
+Transports are optional extras.  Install only the transports you need, or all:
+
+```
+smpclient[serial]
+smpclient[ble]
+smpclient[all]
+```
+
+The UDP transport has no additional dependencies and is always available.
+
 ### Operating Systems
 
 |   | Windows 11 (x86) | Ubuntu (Arm/x86) | macOS (Arm/x86) |

--- a/src/smpclient/transport/ble.py
+++ b/src/smpclient/transport/ble.py
@@ -7,10 +7,15 @@ import sys
 from typing import Final, Protocol, TypeGuard
 from uuid import UUID
 
-from bleak import BleakClient, BleakGATTCharacteristic, BleakScanner
-from bleak.args.winrt import WinRTClientArgs
-from bleak.backends.client import BaseBleakClient
-from bleak.backends.device import BLEDevice
+try:
+    from bleak import BleakClient, BleakGATTCharacteristic, BleakScanner
+    from bleak.args.winrt import WinRTClientArgs
+    from bleak.backends.client import BaseBleakClient
+    from bleak.backends.device import BLEDevice
+except ImportError as _e:
+    raise ImportError(
+        "BLE transport requires the 'ble' extra. Install with: pip install smpclient[ble]"
+    ) from _e
 from smp import header as smphdr
 from typing_extensions import override
 

--- a/src/smpclient/transport/ble.py
+++ b/src/smpclient/transport/ble.py
@@ -12,10 +12,10 @@ try:
     from bleak.args.winrt import WinRTClientArgs
     from bleak.backends.client import BaseBleakClient
     from bleak.backends.device import BLEDevice
-except ImportError as _e:
-    raise ImportError(
-        "BLE transport requires the 'ble' extra. Install with: pip install smpclient[ble]"
-    ) from _e
+except ModuleNotFoundError as e:
+    if e.name == "bleak":
+        raise ImportError("BLE transport requires the 'ble' extra. Use smpclient[ble]") from e
+    raise
 from smp import header as smphdr
 from typing_extensions import override
 

--- a/src/smpclient/transport/serial.py
+++ b/src/smpclient/transport/serial.py
@@ -13,10 +13,12 @@ from typing import Final
 
 try:
     from serial import Serial, SerialException
-except ImportError as _e:
-    raise ImportError(
-        "Serial transport requires the 'serial' extra. Install with: pip install smpclient[serial]"
-    ) from _e
+except ModuleNotFoundError as e:
+    if e.name == "serial":
+        raise ImportError(
+            "Serial transport requires the 'serial' extra. Use smpclient[serial]"
+        ) from e
+    raise
 from smp import packet as smppacket
 from typing_extensions import override
 

--- a/src/smpclient/transport/serial.py
+++ b/src/smpclient/transport/serial.py
@@ -11,7 +11,12 @@ from enum import IntEnum, unique
 from functools import cached_property
 from typing import Final
 
-from serial import Serial, SerialException
+try:
+    from serial import Serial, SerialException
+except ImportError as _e:
+    raise ImportError(
+        "Serial transport requires the 'serial' extra. Install with: pip install smpclient[serial]"
+    ) from _e
 from smp import packet as smppacket
 from typing_extensions import override
 

--- a/uv.lock
+++ b/uv.lock
@@ -1977,10 +1977,20 @@ name = "smpclient"
 source = { editable = "." }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11'" },
-    { name = "bleak" },
     { name = "intelhex" },
-    { name = "pyserial" },
     { name = "smp" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "bleak" },
+    { name = "pyserial" },
+]
+ble = [
+    { name = "bleak" },
+]
+serial = [
+    { name = "pyserial" },
 ]
 
 [package.dev-dependencies]
@@ -1993,6 +2003,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "smpclient", extra = ["all"] },
     { name = "taskipy" },
     { name = "types-pyserial" },
 ]
@@ -2008,11 +2019,14 @@ doc = [
 [package.metadata]
 requires-dist = [
     { name = "async-timeout", marker = "python_full_version < '3.11'", specifier = ">=4.0.3" },
-    { name = "bleak", specifier = ">=2.0.0" },
+    { name = "bleak", marker = "extra == 'all'", specifier = ">=2.0.0" },
+    { name = "bleak", marker = "extra == 'ble'", specifier = ">=2.0.0" },
     { name = "intelhex", specifier = ">=2.3.0" },
-    { name = "pyserial", specifier = ">=3.5" },
+    { name = "pyserial", marker = "extra == 'all'", specifier = ">=3.5" },
+    { name = "pyserial", marker = "extra == 'serial'", specifier = ">=3.5" },
     { name = "smp", specifier = ">=4.0.2" },
 ]
+provides-extras = ["all", "ble", "serial", "udp"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2024,6 +2038,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.12.0" },
+    { name = "smpclient", extras = ["all"] },
     { name = "taskipy", specifier = ">=1" },
     { name = "types-pyserial", specifier = ">=3.5.0.11" },
 ]


### PR DESCRIPTION
Use [ble], [serial], or [all] to enable the transports that are required.

Existing projects are encouraged to use [all] to minimize migration friction.

This is needed for downstream applications, particularly those deployed on embedded linux, that may not want to bring in dependency trees that they are not using, particularly those that would have heavy OS dependencies, like BLE.

Existing projects can migrate safely by changing `smpclient` -> `smpclient[all]`.

UDP transport support is builtin to python so it is always available.

FYI @otavio this may open the door to slimming (but complicating) the nix builds. That said, we don't intend to release an smpmgr that doesn't have all transports enabled.