### PR TITLE
fix(client): readable SMPValidationException on unparseable frame

### DIFF
--- a/src/smpclient/__init__.py
+++ b/src/smpclient/__init__.py
@@ -41,14 +41,14 @@ import traceback
 from collections.abc import AsyncIterator
 from hashlib import sha256
 from types import TracebackType
-from typing import Final, TypeVar
+from typing import Final, Type, TypeVar
 
 from pydantic import ValidationError
 from smp import header as smpheader
 from smp import message as smpmsg
 from typing_extensions import assert_never
 
-from smpclient.exceptions import SMPBadSequence, SMPUploadError
+from smpclient.exceptions import SMPBadSequence, SMPUploadError, SMPValidationException
 from smpclient.generics import SMPRequest, TEr1, TEr2, TRep, error, success
 from smpclient.requests.file_management import FileDownload, FileUpload
 from smpclient.requests.image_management import ImageUploadWrite
@@ -64,6 +64,46 @@ logger = logging.getLogger(__name__)
 
 TUploadRequest = TypeVar("TUploadRequest", ImageUploadWrite, FileUpload)
 """A single-shot upload request whose `data` field is filled to maximize throughput."""
+
+
+def _hexdump_ascii(data: bytes) -> str:
+    """Python 3.12+ has builtint hexdump, prior to that we need to reinvent the wheel."""
+    lines = []
+    for i in range(0, len(data), 16):
+        chunk = data[i : i + 16]
+        hexpart = " ".join(f"{b:02x}" for b in chunk)
+        ascpart = "".join(chr(b) if 32 <= b <= 126 else "." for b in chunk)
+        lines.append(f"\t{i:04x}  {hexpart:<47}  {ascpart}")
+    return "\n".join(lines)
+
+
+def _prettify_validation_error(exc: ValidationError) -> str:
+    lines: list[str] = []
+    for err in exc.errors():
+        err_type = err["type"]
+        msg = err["msg"]
+        loc = ".".join(str(x) for x in err["loc"])
+        lines.append(f"\t\t[{err_type}] {msg}: {loc}; input: {err['input']})")
+    return "\n".join(lines)
+
+
+def _create_smp_validation_exception(
+    header: smpheader.Header,
+    frame: bytes,
+    errs: dict[type[smpmsg.Response], ValidationError],
+) -> SMPValidationException:
+    msg: str = (
+        f"\nFrame could not be parsed as any of:\n\t{[str(t.__name__) for t in errs.keys()]}\n"
+    )
+
+    details = ""
+    details += f"Header:\n\t{header}\n"
+    details += f"Frame:\n{_hexdump_ascii(frame)}\n"
+    details += "Errors:\n"
+    for cls, exc in errs.items():
+        details += f"\tCould not be parsed as {cls.__name__} because {len(exc.errors())} errors:\n{_prettify_validation_error(exc)}\n"
+
+    return SMPValidationException(msg=msg, details=details)
 
 
 class SMPClient:
@@ -137,7 +177,7 @@ class SMPClient:
         Raises:
             TimeoutError: if the request times out
             SMPBadSequence: if the response sequence does not match the request sequence
-            ValidationError: if the response cannot be parsed as a Response or Error
+            SMPValidationException: if the response cannot be parsed as a Response or Error
 
         Examples:
         Usage:
@@ -194,23 +234,22 @@ class SMPClient:
                 f"Bad sequence {header.sequence}, expected {request.header.sequence}"
             )
 
+        errs: dict[Type, ValidationError] = {}
         try:
             return request._Response.loads(frame)  # type: ignore
-        except ValidationError:
-            pass
+        except ValidationError as e:
+            errs[request._Response] = e
         try:
             return request._ErrorV1.loads(frame)
-        except ValidationError:
-            pass
+        except ValidationError as e:
+            errs[request._ErrorV1] = e
         try:
             return request._ErrorV2.loads(frame)
-        except ValidationError:
-            error_message = (
-                f"Response could not by parsed as one of {request._Response}, "
-                f"{request._ErrorV1}, or {request._ErrorV2}. {header=} {frame=}"
-            )
-            logger.error(error_message)
-            raise ValidationError(error_message)
+        except ValidationError as e:
+            errs[request._ErrorV2] = e
+            exc = _create_smp_validation_exception(header, frame, errs)
+            logger.error(exc.msg + exc.details)
+            raise exc from None
 
     async def upload(
         self,

--- a/src/smpclient/__init__.py
+++ b/src/smpclient/__init__.py
@@ -41,9 +41,10 @@ import traceback
 from collections.abc import AsyncIterator
 from hashlib import sha256
 from types import TracebackType
-from typing import Final, Type, TypeVar
+from typing import Final, TypeVar
 
 from pydantic import ValidationError
+from pydantic_core import ErrorDetails
 from smp import header as smpheader
 from smp import message as smpmsg
 from typing_extensions import assert_never
@@ -66,44 +67,49 @@ TUploadRequest = TypeVar("TUploadRequest", ImageUploadWrite, FileUpload)
 """A single-shot upload request whose `data` field is filled to maximize throughput."""
 
 
-def _hexdump_ascii(data: bytes) -> str:
-    """Python 3.12+ has builtint hexdump, prior to that we need to reinvent the wheel."""
-    lines = []
-    for i in range(0, len(data), 16):
-        chunk = data[i : i + 16]
-        hexpart = " ".join(f"{b:02x}" for b in chunk)
-        ascpart = "".join(chr(b) if 32 <= b <= 126 else "." for b in chunk)
-        lines.append(f"\t{i:04x}  {hexpart:<47}  {ascpart}")
-    return "\n".join(lines)
+def _hexdump(frame: bytes) -> str:
+    """Format `frame` as an offset/hex/printable-ASCII dump for readable debug logging."""
+
+    def row(offset: int) -> str:
+        chunk: Final = frame[offset : offset + 16]
+        columns: Final = " ".join(f"{byte:02x}" for byte in chunk)
+        printable: Final = "".join(chr(byte) if 0x20 <= byte <= 0x7E else "." for byte in chunk)
+        return f"\t{offset:04x}  {columns:<47}  {printable}"
+
+    return "\n".join(row(offset) for offset in range(0, len(frame), 16))
 
 
-def _prettify_validation_error(exc: ValidationError) -> str:
-    lines: list[str] = []
-    for err in exc.errors():
-        err_type = err["type"]
-        msg = err["msg"]
-        loc = ".".join(str(x) for x in err["loc"])
-        lines.append(f"\t\t[{err_type}] {msg}: {loc}; input: {err['input']})")
-    return "\n".join(lines)
+def _format_validation_error(error: ValidationError) -> str:
+    def row(detail: ErrorDetails) -> str:
+        location: Final = ".".join(str(part) for part in detail["loc"])
+        return f"\t\t[{detail['type']}] {detail['msg']}: {location}; input: {detail['input']}"
+
+    return "\n".join(row(detail) for detail in error.errors())
 
 
-def _create_smp_validation_exception(
+def _validation_failure(
     header: smpheader.Header,
     frame: bytes,
-    errs: dict[type[smpmsg.Response], ValidationError],
-) -> SMPValidationException:
-    msg: str = (
-        f"\nFrame could not be parsed as any of:\n\t{[str(t.__name__) for t in errs.keys()]}\n"
+    errors: tuple[tuple[type[smpmsg.Response], ValidationError], ...],
+) -> tuple[str, str]:
+    """Return the `(summary, details)` describing why `frame` matched none of `errors`' types."""
+    summary: Final = (
+        "\nFrame could not be parsed as any of:\n"
+        f"\t{[response.__name__ for response, _ in errors]}\n"
     )
-
-    details = ""
-    details += f"Header:\n\t{header}\n"
-    details += f"Frame:\n{_hexdump_ascii(frame)}\n"
-    details += "Errors:\n"
-    for cls, exc in errs.items():
-        details += f"\tCould not be parsed as {cls.__name__} because {len(exc.errors())} errors:\n{_prettify_validation_error(exc)}\n"
-
-    return SMPValidationException(msg=msg, details=details)
+    details: Final = "\n".join(
+        (
+            f"Header:\n\t{header}",
+            f"Frame:\n{_hexdump(frame)}",
+            "Errors:",
+            *(
+                f"\tCould not be parsed as {response.__name__} because "
+                f"{len(error.errors())} error(s):\n{_format_validation_error(error)}"
+                for response, error in errors
+            ),
+        )
+    )
+    return summary, details
 
 
 class SMPClient:
@@ -234,22 +240,23 @@ class SMPClient:
                 f"Bad sequence {header.sequence}, expected {request.header.sequence}"
             )
 
-        errs: dict[Type, ValidationError] = {}
+        errors: list[tuple[type[smpmsg.Response], ValidationError]] = []
         try:
-            return request._Response.loads(frame)  # type: ignore
-        except ValidationError as e:
-            errs[request._Response] = e
+            return request._Response.loads(frame)  # type: ignore[return-value]
+        except ValidationError as error:
+            errors.append((request._Response, error))
         try:
             return request._ErrorV1.loads(frame)
-        except ValidationError as e:
-            errs[request._ErrorV1] = e
+        except ValidationError as error:
+            errors.append((request._ErrorV1, error))
         try:
             return request._ErrorV2.loads(frame)
-        except ValidationError as e:
-            errs[request._ErrorV2] = e
-            exc = _create_smp_validation_exception(header, frame, errs)
-            logger.error(exc.msg + exc.details)
-            raise exc from None
+        except ValidationError as error:
+            errors.append((request._ErrorV2, error))
+
+        summary, details = _validation_failure(header, frame, tuple(errors))
+        logger.error(summary + details)
+        raise SMPValidationException(summary, details) from None
 
     async def upload(
         self,

--- a/src/smpclient/exceptions.py
+++ b/src/smpclient/exceptions.py
@@ -8,3 +8,10 @@ class SMPBadSequence(SMPClientException): ...
 
 
 class SMPUploadError(SMPClientException): ...
+
+
+class SMPValidationException(SMPClientException):
+    def __init__(self, msg: str, details: str) -> None:
+        self.msg: str = msg
+        self.details: str = details
+        super().__init__(msg)

--- a/tests/test_smp_client.py
+++ b/tests/test_smp_client.py
@@ -31,7 +31,7 @@ from smp.os_management import (
 )
 
 from smpclient import SMPClient
-from smpclient.exceptions import SMPBadSequence, SMPUploadError
+from smpclient.exceptions import SMPBadSequence, SMPUploadError, SMPValidationException
 from smpclient.generics import error, error_v1, error_v2, success
 from smpclient.requests.file_management import FileDownload, FileUpload
 from smpclient.requests.image_management import ImageUploadWrite
@@ -163,6 +163,26 @@ async def test_request() -> None:
         assert rep.err.rc == OS_MGMT_RET_RC.UNKNOWN
     else:
         raise AssertionError(f"Unexpected response type: {type(rep)}")
+
+
+@pytest.mark.asyncio
+async def test_request_unparseable_frame() -> None:
+    """A frame matching none of the Response/ErrorV1/ErrorV2 types raises with diagnostics."""
+    m = SMPMockTransport()
+    s = SMPClient(m, "address")
+
+    req = ResetWrite()
+    # A frame from a different group/command can be parsed as none of `ResetWrite`'s types.
+    m.receive.return_value = ImageUploadWriteResponse(sequence=req.header.sequence, off=0).BYTES
+
+    with pytest.raises(SMPValidationException) as exc_info:
+        await s.request(req)
+
+    assert req._Response.__name__ in exc_info.value.msg
+    assert "Header:" in exc_info.value.details
+    assert "Frame:" in exc_info.value.details
+    assert req._ErrorV1.__name__ in exc_info.value.details
+    assert req._ErrorV2.__name__ in exc_info.value.details
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Improves SMP frame-parse failure diagnostics: when a response frame can't be parsed as the request's `Response`, `ErrorV1`, or `ErrorV2`, the client now raises a dedicated `SMPValidationException` carrying a readable summary + a hexdump and per-type Pydantic error breakdown — instead of the current code path, which is itself **broken on `main`**:

```python
raise ValidationError(error_message)  # TypeError: __new__() missing 1 required positional argument: 'line_errors'
```

This revives @JaagupAverin's work from #88 / #91 (both unmerged; the codebase has since moved `smpclient/` → `src/smpclient/` and envr/black → uv/ruff), rebased onto current `main` with his authorship preserved.

## Commits

1. **`chore: Cleanup validation error message.`** — authored by @JaagupAverin (cherry-picked, adapted to the `src/` layout). The substantive fix + diagnostics.
2. **`refactor(client): functional cleanup of validation error diagnostics`** — applies project standards and the #91 review:
   - Functional/immutable formatters (pure inner `row()` helpers over generators, no accumulator mutation).
   - Parse failures collected in an immutable `tuple[type[Response], ValidationError]` rather than `dict[Type, ...]` → resolves the Copilot mypy-invariance flag.
   - Fixes the stray trailing `)` on each error line; corrects the misleading `_hexdump` docstring (no stdlib hexdump builtin).
   - `pydantic_core.ErrorDetails` typing; `raise ... from None` (per @JaagupAverin's suggestion).
   - Adds a regression test asserting the new exception type and its header/frame/per-type diagnostics.

## Example output

```
Frame could not be parsed as any of:
	['ResetWriteResponse', 'OSManagementErrorV1', 'OSManagementErrorV2']
Header:
	Header(op=<OP.WRITE_RSP: 3>, version=<Version.V2: 1>, ... group_id=1, sequence=0, command_id=1)
Frame:
	0000  0b 00 00 06 00 01 00 01 a1 63 6f 66 66 00        .........coff.
Errors:
	Could not be parsed as ResetWriteResponse because 1 error(s):
		[extra_forbidden] Extra inputs are not permitted: off; input: 0
	...
```

## Testing

- `task lint` (ruff + pydoclint) ✓
- `task typecheck` (mypy) ✓
- `task test` → 339 passed, 14 skipped (+1 new test)

Supersedes #91 and revives #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
